### PR TITLE
Clean up and make geometry system threadsafe

### DIFF
--- a/larcorealg/GeoAlgo/CMakeLists.txt
+++ b/larcorealg/GeoAlgo/CMakeLists.txt
@@ -1,7 +1,7 @@
 cet_make(NO_DICTIONARY
          LIBRARIES
-           ${ROOT_CORE}
-           ${ROOT_PHYSICS}
+           ROOT::Core
+           ROOT::Physics
          )
 
 art_dictionary(DICTIONARY_LIBRARIES larcorealg_GeoAlgo)

--- a/larcorealg/Geometry/AuxDetChannelMapAlg.cxx
+++ b/larcorealg/Geometry/AuxDetChannelMapAlg.cxx
@@ -18,33 +18,33 @@ namespace geo{
 
   //----------------------------------------------------------------------------
   size_t AuxDetChannelMapAlg::NearestAuxDet(const double* point,
-                                            std::vector<geo::AuxDetGeo*> const& auxDets) const
+                                            std::vector<geo::AuxDetGeo> const& auxDets) const
   {
     double HalfCenterWidth = 0.;
     double localPoint[3] = {0.};
 
     for(size_t a = 0; a < auxDets.size(); ++a) {
 
-      auxDets[a]->WorldToLocal(point, localPoint);
+      auxDets[a].WorldToLocal(point, localPoint);
 
-      HalfCenterWidth = 0.5 * (auxDets[a]->HalfWidth1() + auxDets[a]->HalfWidth2());
+      HalfCenterWidth = 0.5 * (auxDets[a].HalfWidth1() + auxDets[a].HalfWidth2());
 
-      if(localPoint[2] >= - auxDets[a]->Length()/2       &&
-         localPoint[2] <=   auxDets[a]->Length()/2       &&
-         localPoint[1] >= - auxDets[a]->HalfHeight()     &&
-         localPoint[1] <=   auxDets[a]->HalfHeight()     &&
+      if(localPoint[2] >= - auxDets[a].Length()/2       &&
+         localPoint[2] <=   auxDets[a].Length()/2       &&
+         localPoint[1] >= - auxDets[a].HalfHeight()     &&
+         localPoint[1] <=   auxDets[a].HalfHeight()     &&
          // if AuxDet a is a box, then HalfSmallWidth = HalfWidth
-         localPoint[0] >= - HalfCenterWidth + localPoint[2]*(HalfCenterWidth - auxDets[a]->HalfWidth2())/(0.5 * auxDets[a]->Length()) &&
-         localPoint[0] <=   HalfCenterWidth - localPoint[2]*(HalfCenterWidth - auxDets[a]->HalfWidth2())/(0.5 * auxDets[a]->Length())
+         localPoint[0] >= - HalfCenterWidth + localPoint[2]*(HalfCenterWidth - auxDets[a].HalfWidth2())/(0.5 * auxDets[a].Length()) &&
+         localPoint[0] <=   HalfCenterWidth - localPoint[2]*(HalfCenterWidth - auxDets[a].HalfWidth2())/(0.5 * auxDets[a].Length())
          ) return a;
 
     }// for loop over AudDet a
 
     // throw an exception because we couldn't find the sensitive volume
     throw cet::exception("AuxDetChannelMapAlg") << "Can't find AuxDet for position ("
-					     << point[0] << ","
-					     << point[1] << ","
-					     << point[2] << ")\n";
+                                             << point[0] << ","
+                                             << point[1] << ","
+                                             << point[2] << ")\n";
 
     return UINT_MAX;
 
@@ -52,7 +52,7 @@ namespace geo{
 
   //----------------------------------------------------------------------------
   size_t AuxDetChannelMapAlg::NearestSensitiveAuxDet(const double*                       point,
-                                                     std::vector<geo::AuxDetGeo*> const& auxDets,
+                                                     std::vector<geo::AuxDetGeo> const& auxDets,
                                                      size_t                            & ad) const
   {
     double HalfCenterWidth = 0.;
@@ -60,11 +60,11 @@ namespace geo{
 
     ad = this->NearestAuxDet(point, auxDets);
 
-    geo::AuxDetGeo* adg = auxDets[ad];
+    geo::AuxDetGeo const& adg = auxDets[ad];
 
-    for(size_t a = 0; a < adg->NSensitiveVolume(); ++a) {
+    for(size_t a = 0; a < adg.NSensitiveVolume(); ++a) {
 
-      geo::AuxDetSensitiveGeo const& adsg = adg->SensitiveVolume(a);
+      geo::AuxDetSensitiveGeo const& adsg = adg.SensitiveVolume(a);
       adsg.WorldToLocal(point, localPoint);
 
       HalfCenterWidth = 0.5 * (adsg.HalfWidth1() + adsg.HalfWidth2());
@@ -81,15 +81,15 @@ namespace geo{
 
     // throw an exception because we couldn't find the sensitive volume
     throw cet::exception("Geometry") << "Can't find AuxDetSensitive for position ("
-				     << point[0] << ","
-				     << point[1] << ","
-				     << point[2] << ")\n";
+                                     << point[0] << ","
+                                     << point[1] << ","
+                                     << point[2] << ")\n";
 
     return UINT_MAX;
   }
 
   //----------------------------------------------------------------------------
-  size_t AuxDetChannelMapAlg::ChannelToAuxDet(std::vector<geo::AuxDetGeo*> const& /* auxDets */,
+  size_t AuxDetChannelMapAlg::ChannelToAuxDet(std::vector<geo::AuxDetGeo> const& /* auxDets */,
                                               std::string                  const& detName,
                                               uint32_t                     const& /*channel*/) const
   {
@@ -109,7 +109,7 @@ namespace geo{
   //----------------------------------------------------------------------------
   // the first member of the pair is the index in the auxDets vector for the AuxDetGeo,
   // the second member is the index in the vector of AuxDetSensitiveGeos for that AuxDetGeo
-  std::pair<size_t, size_t> AuxDetChannelMapAlg::ChannelToSensitiveAuxDet(std::vector<geo::AuxDetGeo*> const& auxDets,
+  std::pair<size_t, size_t> AuxDetChannelMapAlg::ChannelToSensitiveAuxDet(std::vector<geo::AuxDetGeo> const& auxDets,
                                                                           std::string                  const& detName,
                                                                           uint32_t                     const& channel) const
   {
@@ -125,12 +125,12 @@ namespace geo{
         return std::make_pair(adGeoIdx, itr->second[channel].second);
 
       throw cet::exception("Geometry") << "Given AuxDetSensitive channel, " << channel
-				       << ", cannot be found in vector associated to AuxDetGeo index: "
-				       << adGeoIdx << ". Vector has size " << itr->second.size();
+                                       << ", cannot be found in vector associated to AuxDetGeo index: "
+                                       << adGeoIdx << ". Vector has size " << itr->second.size();
     }
 
     throw cet::exception("Geometry") << "Given AuxDetGeo with index " << adGeoIdx
-				     << " does not correspond to any vector of sensitive volumes";
+                                     << " does not correspond to any vector of sensitive volumes";
 
     return std::make_pair(adGeoIdx, UINT_MAX);
   }

--- a/larcorealg/Geometry/AuxDetChannelMapAlg.h
+++ b/larcorealg/Geometry/AuxDetChannelMapAlg.h
@@ -39,28 +39,28 @@ namespace geo{
     // method returns the entry in the sorted AuxDetGeo vector so that the
     // Geometry in turn can return that object
     virtual size_t  NearestAuxDet          (const double*                       point,
-                                            std::vector<geo::AuxDetGeo*> const& auxDets) const;
+                                            std::vector<geo::AuxDetGeo> const& auxDets) const;
     virtual size_t  NearestSensitiveAuxDet (const double*                       point,
-                                            std::vector<geo::AuxDetGeo*> const& auxDets,
+                                            std::vector<geo::AuxDetGeo> const& auxDets,
                                             size_t                            & ad) const;
-    virtual size_t  ChannelToAuxDet        (std::vector<geo::AuxDetGeo*> const& auxDets,
+    virtual size_t  ChannelToAuxDet        (std::vector<geo::AuxDetGeo> const& auxDets,
                                             std::string                  const& detName,
                                             uint32_t                     const& channel) const;
-    virtual std::pair<size_t, size_t>  ChannelToSensitiveAuxDet(std::vector<geo::AuxDetGeo*> const& auxDets,
-                                                                std::string                  const& detName,
-                                                                uint32_t                     const& channel) const;
+    virtual std::pair<size_t, size_t>  ChannelToSensitiveAuxDet(std::vector<geo::AuxDetGeo> const& auxDets,
+                                                                std::string                 const& detName,
+                                                                uint32_t                    const& channel) const;
 
     // Experiments must implement these method. It accounts for auxiliary detectors like
     // Multiwire proportional chambers where there is only a single sensitive volume, but
     // multiple channels running through that volume.
-    virtual uint32_t PositionToAuxDetChannel(double                       const  worldLoc[3],
-                                             std::vector<geo::AuxDetGeo*> const& auxDets,
-                                             size_t                            & ad,
-                                             size_t      		                   & sv) const = 0;
+    virtual uint32_t PositionToAuxDetChannel(double                      const  worldLoc[3],
+                                             std::vector<geo::AuxDetGeo> const& auxDets,
+                                             size_t                           & ad,
+                                             size_t                           & sv) const = 0;
 
     virtual const TVector3 AuxDetChannelToPosition(uint32_t                     const& channel,
                                                    std::string                  const& auxDetName,
-                                                   std::vector<geo::AuxDetGeo*> const& auxDets) const = 0;
+                                                   std::vector<geo::AuxDetGeo> const& auxDets) const = 0;
 
  protected:
 
@@ -69,7 +69,6 @@ namespace geo{
    std::map<size_t, std::vector<chanAndSV> > fADGeoToChannelAndSV; ///< map the AuxDetGeo index to a vector of
                                                                    ///< pairs corresponding to the channel and
                                                                    ///< AuxDetSensitiveGeo index
-
  };
 }
 #endif // GEO_AUXDETCHANNELMAPALG_H

--- a/larcorealg/Geometry/AuxDetGeo.cxx
+++ b/larcorealg/Geometry/AuxDetGeo.cxx
@@ -11,7 +11,6 @@
 // LArSoft libraries
 #include "larcorealg/Geometry/geo_vectors_utils.h" // geo::vect namespace
 #include "larcorealg/Geometry/GeoObjectSorter.h"
-#include "larcorealg/CoreUtils/SortByPointers.h"
 
 // ROOT
 #include "TGeoTrd2.h"
@@ -143,10 +142,7 @@ namespace geo{
   //......................................................................
   void AuxDetGeo::SortSubVolumes(GeoObjectSorter const& sorter)
   {
-    // the sorter interface requires a vector of pointers;
-    // sorting is faster, but some gymnastics is required:
-    util::SortByPointers
-      (fSensitive, [&sorter](auto& coll){ sorter.SortAuxDetSensitive(coll); });
+    sorter.SortAuxDetSensitive(fSensitive);
   }
 
   //......................................................................

--- a/larcorealg/Geometry/AuxDetGeoObjectSorter.h
+++ b/larcorealg/Geometry/AuxDetGeoObjectSorter.h
@@ -26,10 +26,8 @@ namespace geo{
 
     virtual ~AuxDetGeoObjectSorter() = default;
 
-    virtual void SortAuxDets        (std::vector<geo::AuxDetGeo*>          & adgeo)   const = 0;
-    virtual void SortAuxDetSensitive(std::vector<geo::AuxDetSensitiveGeo*> & adsgeo)  const = 0;
-
-  private:
+    virtual void SortAuxDets        (std::vector<geo::AuxDetGeo>          & adgeo)   const = 0;
+    virtual void SortAuxDetSensitive(std::vector<geo::AuxDetSensitiveGeo> & adsgeo)  const = 0;
 
   };
 

--- a/larcorealg/Geometry/AuxDetGeometryCore.cxx
+++ b/larcorealg/Geometry/AuxDetGeometryCore.cxx
@@ -82,35 +82,22 @@ namespace geo {
       );
     geo::GeoNodePath path{ gGeoManager->GetTopNode() };
 
-    // channel mapping interface demands a vector of pointers to auxiliary
-    // detectors for several methods; and Gianluca is not going to fix that
-    // this time; so we waste some time and health in conversions.
-    auto auxDets =
-      geo::GeometryBuilder::moveToColl(builder.extractAuxiliaryDetectors(path));
-    AuxDets().clear();
-    AuxDets().reserve(auxDets.size());
-    for (geo::AuxDetGeo& auxDet: auxDets) {
-      auto* pAuxDet = new geo::AuxDetGeo(std::move(auxDet));
-      AuxDets().push_back(pAuxDet);
-    }
+    AuxDets() = builder.extractAuxiliaryDetectors(path);
 
     fGDMLfile = gdmlfile;
     fROOTfile = rootfile;
 
     mf::LogInfo("AuxDetGeometryCore") << "New detector geometry loaded from "
-				      << "\n\t" << fROOTfile
-				      << "\n\t" << fGDMLfile << "\n";
+                                      << "\n\t" << fROOTfile
+                                      << "\n\t" << fGDMLfile << "\n";
 
   } // AuxDetGeometryCore::LoadGeometryFile()
 
   //......................................................................
   void AuxDetGeometryCore::ClearGeometry()
   {
-    // auxiliary detectors
-    std::for_each(AuxDets().begin(), AuxDets().end(), std::default_delete<AuxDetGeo>());
     AuxDets().clear();
-
-  } // AuxDetGeometryCore::ClearGeometry()
+  }
 
 
   //......................................................................
@@ -118,9 +105,9 @@ namespace geo {
   {
     if( aid > NAuxDets() - 1)
       throw cet::exception("Geometry") << "Requested AuxDet index " << aid
-				       << " is out of range: " << NAuxDets();
+                                       << " is out of range: " << NAuxDets();
 
-    return AuxDets()[aid]->NSensitiveVolume();
+    return AuxDets()[aid].NSensitiveVolume();
   }
 
   //......................................................................
@@ -136,10 +123,10 @@ namespace geo {
   {
     if(ad >= NAuxDets())
     throw cet::exception("AuxDetGeometryCore") << "AuxDet "
-					       << ad
-					       << " does not exist\n";
+                                               << ad
+                                               << " does not exist\n";
 
-    return *(AuxDets()[ad]);
+    return AuxDets()[ad];
   }
 
 
@@ -147,11 +134,11 @@ namespace geo {
   unsigned int AuxDetGeometryCore::FindAuxDetAtPosition(double const  worldPos[3]) const
   {
     return fChannelMapAlg->NearestAuxDet(worldPos, AuxDets());
-  } // AuxDetGeometryCore::FindAuxDetAtPosition()
+  }
 
   //......................................................................
   const AuxDetGeo& AuxDetGeometryCore::PositionToAuxDet(double const  worldLoc[3],
-							unsigned int &ad) const
+                                                        unsigned int &ad) const
   {
     // locate the desired Auxiliary Detector
     ad = this->FindAuxDetAtPosition(worldLoc);
@@ -161,19 +148,17 @@ namespace geo {
 
   //......................................................................
   void AuxDetGeometryCore::FindAuxDetSensitiveAtPosition(double const worldPos[3],
-							 size_t     & adg,
-							 size_t     & sv) const
+                                                         size_t     & adg,
+                                                         size_t     & sv) const
   {
     adg = this->FindAuxDetAtPosition(worldPos);
     sv  = fChannelMapAlg->NearestSensitiveAuxDet(worldPos, AuxDets(), adg);
-
-    return;
-  } // AuxDetGeometryCore::FindAuxDetAtPosition()
+  }
 
   //......................................................................
   const AuxDetSensitiveGeo& AuxDetGeometryCore::PositionToAuxDetSensitive(double const worldLoc[3],
-									  size_t      &ad,
-									  size_t      &sv) const
+                                                                          size_t      &ad,
+                                                                          size_t      &sv) const
   {
     // locate the desired Auxiliary Detector
     this->FindAuxDetSensitiveAtPosition(worldLoc, ad, sv);
@@ -182,22 +167,22 @@ namespace geo {
 
   //......................................................................
   uint32_t AuxDetGeometryCore::PositionToAuxDetChannel(double const worldLoc[3],
-							     size_t      &ad,
-							     size_t      &sv) const
+                                                       size_t      &ad,
+                                                       size_t      &sv) const
   {
     return fChannelMapAlg->PositionToAuxDetChannel(worldLoc, AuxDets(), ad, sv);
   }
 
   //......................................................................
   TVector3 AuxDetGeometryCore::AuxDetChannelToPosition(uint32_t    const& channel,
-							     std::string const& auxDetName) const
+                                                       std::string const& auxDetName) const
   {
     return fChannelMapAlg->AuxDetChannelToPosition(channel, auxDetName, AuxDets());
   }
 
   //......................................................................
   const AuxDetGeo& AuxDetGeometryCore::ChannelToAuxDet(std::string const& auxDetName,
-						       uint32_t    const& channel) const
+                                                       uint32_t    const& channel) const
   {
     size_t adIdx = fChannelMapAlg->ChannelToAuxDet(AuxDets(), auxDetName, channel);
     return this->AuxDet(adIdx);
@@ -205,7 +190,7 @@ namespace geo {
 
   //......................................................................
   const AuxDetSensitiveGeo& AuxDetGeometryCore::ChannelToAuxDetSensitive(std::string const& auxDetName,
-									 uint32_t    const& channel) const
+                                                                         uint32_t    const& channel) const
   {
     auto idx = fChannelMapAlg->ChannelToSensitiveAuxDet(AuxDets(), auxDetName, channel);
     return this->AuxDet(idx.first).SensitiveVolume(idx.second);

--- a/larcorealg/Geometry/AuxDetGeometryCore.cxx
+++ b/larcorealg/Geometry/AuxDetGeometryCore.cxx
@@ -43,22 +43,14 @@ namespace geo {
     , fBuilderParameters(pset.get<fhicl::ParameterSet>("Builder", fhicl::ParameterSet()))
   {
     std::transform(fDetectorName.begin(), fDetectorName.end(), fDetectorName.begin(), ::tolower);
-  } // AuxDetGeometryCore::AuxDetGeometryCore()
-
-
-  //......................................................................
-  AuxDetGeometryCore::~AuxDetGeometryCore()
-  {
-    ClearGeometry();
-  } // AuxDetGeometryCore::~AuxDetGeometryCore()
-
+  }
 
   //......................................................................
-  void AuxDetGeometryCore::ApplyChannelMap(std::shared_ptr<geo::AuxDetChannelMapAlg> pChannelMap)
+  void AuxDetGeometryCore::ApplyChannelMap(std::unique_ptr<geo::AuxDetChannelMapAlg> pChannelMap)
   {
     pChannelMap->Initialize(fGeoData);
-    fChannelMapAlg = pChannelMap;
-  } // AuxDetGeometryCore::ApplyChannelMap()
+    fChannelMapAlg = move(pChannelMap);
+  }
 
   //......................................................................
   void AuxDetGeometryCore::LoadGeometryFile(std::string gdmlfile, std::string rootfile)

--- a/larcorealg/Geometry/AuxDetGeometryCore.h
+++ b/larcorealg/Geometry/AuxDetGeometryCore.h
@@ -9,6 +9,7 @@
 #define GEO_AUXDETGEOMETRYCORE_H
 
 // LArSoft libraries
+#include "larcorealg/Geometry/AuxDetGeo.h"
 
 // Framework and infrastructure libraries
 #include "fhiclcpp/ParameterSet.h"
@@ -28,7 +29,6 @@ namespace geo {
 
   // Forward declarations within namespace.
   class AuxDetChannelMapAlg;
-  class AuxDetGeo;
   class AuxDetSensitiveGeo;
 
   /// Data in the geometry description
@@ -36,7 +36,7 @@ namespace geo {
   struct AuxDetGeometryData_t {
 
     /// Type of list of auxiliary detectors
-    using AuxDetList_t = std::vector<AuxDetGeo*>;
+    using AuxDetList_t = std::vector<AuxDetGeo>;
 
     AuxDetList_t   auxDets;   ///< The auxiliary detectors
 
@@ -165,7 +165,7 @@ namespace geo {
     //
 
     /// Returns the full list of pointer to the auxiliary detectors
-    std::vector<AuxDetGeo*> const& AuxDetGeoVec() const { return AuxDets(); }
+    std::vector<AuxDetGeo> const& AuxDetGeoVec() const { return AuxDets(); }
 
     /**
      * @brief Returns the specified auxiliary detector
@@ -205,7 +205,7 @@ namespace geo {
      * @todo what happens if it does not exist?
      */
     AuxDetGeo const& PositionToAuxDet(double const worldLoc[3],
-				      unsigned int &ad) const;
+                                      unsigned int &ad) const;
 
     /**
      * @brief Returns the auxiliary detector at specified location
@@ -221,18 +221,18 @@ namespace geo {
                                                         size_t     & sv) const;
 
     uint32_t                 PositionToAuxDetChannel(double const worldLoc[3],
-						     size_t     & ad,
-						     size_t     & sv) const;
+                                                     size_t     & ad,
+                                                     size_t     & sv) const;
     TVector3                 AuxDetChannelToPosition(uint32_t    const& channel,
-						     std::string const& auxDetName) const;
+                                                     std::string const& auxDetName) const;
 
 
     const AuxDetGeo&         ChannelToAuxDet(std::string const& auxDetName,
-					     uint32_t    const& channel) const; // return the AuxDetGeo for the given detector
+                                             uint32_t    const& channel) const; // return the AuxDetGeo for the given detector
                                                                                 // name and channel
 
     const AuxDetSensitiveGeo& ChannelToAuxDetSensitive(std::string const& auxDetName,
-						       uint32_t    const& channel) const; // return the AuxDetSensitiveGeo for the given
+                                                       uint32_t    const& channel) const; // return the AuxDetSensitiveGeo for the given
 
     /// @name Geometry initialization
     /// @{

--- a/larcorealg/Geometry/AuxDetGeometryCore.h
+++ b/larcorealg/Geometry/AuxDetGeometryCore.h
@@ -103,9 +103,6 @@ namespace geo {
      */
     AuxDetGeometryCore(fhicl::ParameterSet const& pset);
 
-    /// Destructor
-    ~AuxDetGeometryCore();
-
     // You shall not copy or move or assign me!
     AuxDetGeometryCore(AuxDetGeometryCore const&) = delete;
     AuxDetGeometryCore(AuxDetGeometryCore&&) = delete;
@@ -287,7 +284,7 @@ namespace geo {
      * This method needs to be called after LoadGeometryFile() to complete the
      * geometry initialization.
      */
-    void ApplyChannelMap(std::shared_ptr<geo::AuxDetChannelMapAlg> pChannelMap);
+    void ApplyChannelMap(std::unique_ptr<geo::AuxDetChannelMapAlg> pChannelMap);
     /// @}
 
 
@@ -313,7 +310,7 @@ namespace geo {
     std::string    fGDMLfile;       ///< path to geometry file used for Geant4 simulation
     std::string    fROOTfile;       ///< path to geometry file for geometry in GeometryCore
     fhicl::ParameterSet fBuilderParameters; ///< Configuration of geometry builder.
-    std::shared_ptr<const geo::AuxDetChannelMapAlg> fChannelMapAlg;  ///< Object containing the channel to wire mapping
+    std::unique_ptr<const geo::AuxDetChannelMapAlg> fChannelMapAlg;  ///< Object containing the channel to wire mapping
   }; // class GeometryCore
 
 } // namespace geo

--- a/larcorealg/Geometry/CMakeLists.txt
+++ b/larcorealg/Geometry/CMakeLists.txt
@@ -6,10 +6,10 @@ cet_make(
           ${FHICLCPP}
           cetlib
           cetlib_except
-          ${ROOT_CORE}
-          ${ROOT_PHYSICS}
-          ${ROOT_GEOM}
-          ${ROOT_GENVECTOR}
+          ROOT::Core
+          ROOT::Physics
+          ROOT::Geom
+          ROOT::GenVector
         )
 
 install_headers(SUBDIRS "details")

--- a/larcorealg/Geometry/ChannelMapAlg.cxx
+++ b/larcorealg/Geometry/ChannelMapAlg.cxx
@@ -78,33 +78,33 @@ namespace geo{
 
   //----------------------------------------------------------------------------
   size_t ChannelMapAlg::NearestAuxDet(const double* point,
-				      std::vector<geo::AuxDetGeo*> const& auxDets) const
+                                      std::vector<geo::AuxDetGeo> const& auxDets) const
   {
     double HalfCenterWidth = 0.;
     double localPoint[3] = {0.};
 
     for(size_t a = 0; a < auxDets.size(); ++a) {
 
-      auxDets[a]->WorldToLocal(point, localPoint);
+      auxDets[a].WorldToLocal(point, localPoint);
 
-      HalfCenterWidth = 0.5 * (auxDets[a]->HalfWidth1() + auxDets[a]->HalfWidth2());
+      HalfCenterWidth = 0.5 * (auxDets[a].HalfWidth1() + auxDets[a].HalfWidth2());
 
-      if( localPoint[2] >= - auxDets[a]->Length()/2       &&
-	  localPoint[2] <=   auxDets[a]->Length()/2       &&
-	  localPoint[1] >= - auxDets[a]->HalfHeight()     &&
-	  localPoint[1] <=   auxDets[a]->HalfHeight()     &&
-	  // if AuxDet a is a box, then HalfSmallWidth = HalfWidth
-	  localPoint[0] >= - HalfCenterWidth + localPoint[2]*(HalfCenterWidth - auxDets[a]->HalfWidth2())/(0.5 * auxDets[a]->Length()) &&
-	  localPoint[0] <=   HalfCenterWidth - localPoint[2]*(HalfCenterWidth - auxDets[a]->HalfWidth2())/(0.5 * auxDets[a]->Length())
-	  ) return a;
+      if( localPoint[2] >= - auxDets[a].Length()/2       &&
+          localPoint[2] <=   auxDets[a].Length()/2       &&
+          localPoint[1] >= - auxDets[a].HalfHeight()     &&
+          localPoint[1] <=   auxDets[a].HalfHeight()     &&
+          // if AuxDet a is a box, then HalfSmallWidth = HalfWidth
+          localPoint[0] >= - HalfCenterWidth + localPoint[2]*(HalfCenterWidth - auxDets[a].HalfWidth2())/(0.5 * auxDets[a].Length()) &&
+          localPoint[0] <=   HalfCenterWidth - localPoint[2]*(HalfCenterWidth - auxDets[a].HalfWidth2())/(0.5 * auxDets[a].Length())
+          ) return a;
 
     }// for loop over AudDet a
 
     // throw an exception because we couldn't find the sensitive volume
     throw cet::exception("ChannelMap") << "Can't find AuxDet for position ("
-					     << point[0] << ","
-					     << point[1] << ","
-					     << point[2] << ")\n";
+                                             << point[0] << ","
+                                             << point[1] << ","
+                                             << point[2] << ")\n";
 
     return UINT_MAX;
 
@@ -112,45 +112,45 @@ namespace geo{
 
   //----------------------------------------------------------------------------
   size_t ChannelMapAlg::NearestSensitiveAuxDet(const double* point,
-					       std::vector<geo::AuxDetGeo*> const& auxDets) const
+                                               std::vector<geo::AuxDetGeo> const& auxDets) const
   {
     double HalfCenterWidth = 0.;
     double localPoint[3] = {0.};
 
     size_t auxDetIdx = this->NearestAuxDet(point, auxDets);
 
-    geo::AuxDetGeo* adg = auxDets[auxDetIdx];
+    geo::AuxDetGeo const& adg = auxDets[auxDetIdx];
 
-    for(size_t a = 0; a < adg->NSensitiveVolume(); ++a) {
+    for(size_t a = 0; a < adg.NSensitiveVolume(); ++a) {
 
-      geo::AuxDetSensitiveGeo const& adsg = adg->SensitiveVolume(a);
+      geo::AuxDetSensitiveGeo const& adsg = adg.SensitiveVolume(a);
       adsg.WorldToLocal(point, localPoint);
 
       HalfCenterWidth = 0.5 * (adsg.HalfWidth1() + adsg.HalfWidth2());
 
       if( localPoint[2] >= - adsg.Length()/2       &&
-	  localPoint[2] <=   adsg.Length()/2       &&
-	  localPoint[1] >= - adsg.HalfHeight()     &&
-	  localPoint[1] <=   adsg.HalfHeight()     &&
-	  // if AuxDet a is a box, then HalfSmallWidth = HalfWidth
-	  localPoint[0] >= - HalfCenterWidth + localPoint[2]*(HalfCenterWidth - adsg.HalfWidth2())/(0.5 * adsg.Length()) &&
-	  localPoint[0] <=   HalfCenterWidth - localPoint[2]*(HalfCenterWidth - adsg.HalfWidth2())/(0.5 * adsg.Length())
-	  ) return a;
+          localPoint[2] <=   adsg.Length()/2       &&
+          localPoint[1] >= - adsg.HalfHeight()     &&
+          localPoint[1] <=   adsg.HalfHeight()     &&
+          // if AuxDet a is a box, then HalfSmallWidth = HalfWidth
+          localPoint[0] >= - HalfCenterWidth + localPoint[2]*(HalfCenterWidth - adsg.HalfWidth2())/(0.5 * adsg.Length()) &&
+          localPoint[0] <=   HalfCenterWidth - localPoint[2]*(HalfCenterWidth - adsg.HalfWidth2())/(0.5 * adsg.Length())
+          ) return a;
     }// for loop over AuxDetSensitive a
 
     // throw an exception because we couldn't find the sensitive volume
     throw cet::exception("Geometry") << "Can't find AuxDetSensitive for position ("
-				     << point[0] << ","
-				     << point[1] << ","
-				     << point[2] << ")\n";
+                                     << point[0] << ","
+                                     << point[1] << ","
+                                     << point[2] << ")\n";
 
     return UINT_MAX;
   }
 
   //----------------------------------------------------------------------------
-  size_t ChannelMapAlg::ChannelToAuxDet(std::vector<geo::AuxDetGeo*> const& /* auxDets */,
-					std::string                  const& detName,
-					uint32_t                     const& /*channel*/) const
+  size_t ChannelMapAlg::ChannelToAuxDet(std::vector<geo::AuxDetGeo> const& /* auxDets */,
+                                        std::string                 const& detName,
+                                        uint32_t                    const& /*channel*/) const
   {
     // loop over the map of AuxDet names to Geo object numbers to determine which auxdet
     // we have.  If no name in the map matches the provided string, throw an exception
@@ -166,9 +166,9 @@ namespace geo{
   //----------------------------------------------------------------------------
   // the first member of the pair is the index in the auxDets vector for the AuxDetGeo,
   // the second member is the index in the vector of AuxDetSensitiveGeos for that AuxDetGeo
-  std::pair<size_t, size_t> ChannelMapAlg::ChannelToSensitiveAuxDet(std::vector<geo::AuxDetGeo*> const& auxDets,
-								    std::string                  const& detName,
-								    uint32_t                     const& channel) const
+  std::pair<size_t, size_t> ChannelMapAlg::ChannelToSensitiveAuxDet(std::vector<geo::AuxDetGeo> const& auxDets,
+                                                                    std::string                 const& detName,
+                                                                    uint32_t                    const& channel) const
   {
     size_t adGeoIdx     = this->ChannelToAuxDet(auxDets, detName, channel);
 
@@ -179,15 +179,15 @@ namespace geo{
 
       // get the vector of channels to AuxDetSensitiveGeo index
       if( channel < itr->second.size() )
-	return std::make_pair(adGeoIdx, itr->second[channel]);
+        return std::make_pair(adGeoIdx, itr->second[channel]);
 
       throw cet::exception("Geometry") << "Given AuxDetSensitive channel, " << channel
-				       << ", cannot be found in vector associated to AuxDetGeo index: "
-				       << adGeoIdx << ". Vector has size " << itr->second.size();
+                                       << ", cannot be found in vector associated to AuxDetGeo index: "
+                                       << adGeoIdx << ". Vector has size " << itr->second.size();
     }
 
     throw cet::exception("Geometry") << "Given AuxDetGeo with index " << adGeoIdx
-				     << " does not correspond to any vector of sensitive volumes";
+                                     << " does not correspond to any vector of sensitive volumes";
 
     return std::make_pair(adGeoIdx, UINT_MAX);
   }

--- a/larcorealg/Geometry/ChannelMapAlg.h
+++ b/larcorealg/Geometry/ChannelMapAlg.h
@@ -418,7 +418,7 @@ namespace geo{
      * @return index of auxiliary detector within auxDets
      */
     virtual size_t NearestAuxDet
-      (const double* point, std::vector<geo::AuxDetGeo*> const& auxDets) const;
+      (const double* point, std::vector<geo::AuxDetGeo> const& auxDets) const;
 
     /**
      * @brief Returns sensitive auxiliary detector closest to specified point
@@ -427,7 +427,7 @@ namespace geo{
      * @return index of sought sensitive auxiliary detector within auxDets
      */
     virtual size_t NearestSensitiveAuxDet
-      (const double* point, std::vector<geo::AuxDetGeo*> const& auxDets) const;
+      (const double* point, std::vector<geo::AuxDetGeo> const& auxDets) const;
 
     /**
      * @brief Returns the index of the detector containing the specified channel
@@ -440,9 +440,9 @@ namespace geo{
      *      in the arguments and instead relies on a cache that is never filled
      *      by this class (derived classes can fill it though).
      */
-    virtual size_t ChannelToAuxDet(std::vector<geo::AuxDetGeo*> const& auxDets,
-                                   std::string                  const& detName,
-                                   uint32_t                     const& channel
+    virtual size_t ChannelToAuxDet(std::vector<geo::AuxDetGeo> const& auxDets,
+                                   std::string                 const& detName,
+                                   uint32_t                    const& channel
                                    ) const;
 
     /**
@@ -453,9 +453,9 @@ namespace geo{
      * @return index of the sought sensitive auxiliary detector within auxDets
      */
     virtual std::pair<size_t, size_t> ChannelToSensitiveAuxDet(
-      std::vector<geo::AuxDetGeo*> const& auxDets,
-      std::string                  const& detName,
-      uint32_t                     const& channel
+      std::vector<geo::AuxDetGeo> const& auxDets,
+      std::string                 const& detName,
+      uint32_t                    const& channel
       ) const;
 
     /// @}

--- a/larcorealg/Geometry/CryostatGeo.cxx
+++ b/larcorealg/Geometry/CryostatGeo.cxx
@@ -8,7 +8,6 @@
 #include "larcorealg/Geometry/CryostatGeo.h"
 
 // LArSoft includes
-#include "larcorealg/CoreUtils/SortByPointers.h"
 #include "larcorealg/Geometry/GeoObjectSorter.h"          // for GeoObjectSo...
 
 // Framework includes
@@ -63,23 +62,13 @@ namespace geo{
   // sort the TPCGeo objects, and the PlaneGeo objects inside
   void CryostatGeo::SortSubVolumes(geo::GeoObjectSorter const& sorter)
   {
-    //
-    // TPCs
-    //
-    util::SortByPointers
-      (fTPCs, [&sorter](auto& coll){ sorter.SortTPCs(coll); });
+    sorter.SortTPCs(fTPCs);
 
     for (geo::TPCGeo& TPC: fTPCs) {
       TPC.SortSubVolumes(sorter);
-    } // for TPCs
+    }
 
-    //
-    // optical detectors
-    //
-    util::SortByPointers
-      (fOpDets, [&sorter](auto& coll){ sorter.SortOpDets(coll); });
-
-
+    sorter.SortOpDets(fOpDets);
   } // CryostatGeo::SortSubVolumes()
 
 
@@ -119,7 +108,7 @@ namespace geo{
   {
     if(iopdet >= fOpDets.size()){
       throw cet::exception("OpDetOutOfRange") << "Request for non-existant OpDet "
-					      << iopdet;
+                                              << iopdet;
     }
 
     return fOpDets[iopdet];
@@ -129,7 +118,7 @@ namespace geo{
   //......................................................................
   auto CryostatGeo::IterateElements() const -> ElementIteratorBox
     { return fTPCs; }
-  
+
 
   //......................................................................
   // wiggle is 1+a small number to allow for rounding errors on the

--- a/larcorealg/Geometry/GeoObjectSorter.cxx
+++ b/larcorealg/Geometry/GeoObjectSorter.cxx
@@ -13,23 +13,23 @@
 
 namespace geo{
 
-    static bool sortorderOpDets     (const OpDetGeo* t1, const OpDetGeo* t2)
-    {
-      double xyz1[3] = {0.}, xyz2[3] = {0.};
-      double local[3] = {0.};
-      t1->LocalToWorld(local, xyz1);
-      t2->LocalToWorld(local, xyz2);
+  static bool sortorderOpDets(const OpDetGeo& t1, const OpDetGeo& t2)
+  {
+    double xyz1[3] = {0.}, xyz2[3] = {0.};
+    double local[3] = {0.};
+    t1.LocalToWorld(local, xyz1);
+    t2.LocalToWorld(local, xyz2);
 
-      if(xyz1[2]!=xyz2[2])
-        return xyz1[2]>xyz2[2];
-      else if(xyz1[1]!=xyz2[1])
-        return xyz1[1]>xyz2[1];
-      else
-        return xyz1[0]>xyz2[0];
-    }
+    if(xyz1[2]!=xyz2[2])
+      return xyz1[2]>xyz2[2];
+    else if(xyz1[1]!=xyz2[1])
+      return xyz1[1]>xyz2[1];
+    else
+      return xyz1[0]>xyz2[0];
+  }
 
-    void GeoObjectSorter::SortOpDets(std::vector<geo::OpDetGeo*> & opdet) const {
-      std::sort(opdet.begin(), opdet.end(), sortorderOpDets);
-      return;
-    }
+  void GeoObjectSorter::SortOpDets(std::vector<geo::OpDetGeo> & opdet) const
+  {
+    std::sort(opdet.begin(), opdet.end(), sortorderOpDets);
+  }
 }

--- a/larcorealg/Geometry/GeoObjectSorter.h
+++ b/larcorealg/Geometry/GeoObjectSorter.h
@@ -10,11 +10,11 @@
 
 #include <vector>
 
+#include "larcorealg/Geometry/AuxDetGeo.h"
 #include "larcoreobj/SimpleTypesAndConstants/geo_types.h"
 
 namespace geo{
 
-  class AuxDetGeo;
   class AuxDetSensitiveGeo;
   class CryostatGeo;
   class TPCGeo;
@@ -23,21 +23,17 @@ namespace geo{
   class OpDetGeo;
   /// @ingroup Geometry
   class GeoObjectSorter {
-
   public:
-
     virtual ~GeoObjectSorter() = default;
 
-    virtual void SortAuxDets        (std::vector<geo::AuxDetGeo*>          & adgeo)   const = 0;
-    virtual void SortAuxDetSensitive(std::vector<geo::AuxDetSensitiveGeo*> & adsgeo)  const = 0;
-    virtual void SortCryostats      (std::vector<geo::CryostatGeo*>        & cgeo)    const = 0;
-    virtual void SortTPCs     	    (std::vector<geo::TPCGeo*>      	  & tgeo)     const = 0;
-    virtual void SortPlanes   	    (std::vector<geo::PlaneGeo*>       	  & pgeo,
-			      	     geo::DriftDirection_t     	    const & driftDir) const = 0;
-    virtual void SortWires    	    (std::vector<geo::WireGeo*>     	  & wgeo)     const = 0;
-    virtual void SortOpDets        (std::vector<geo::OpDetGeo*>          & opdet) const;
-  private:
-
+    virtual void SortAuxDets(std::vector<geo::AuxDetGeo>& adgeo) const = 0;
+    virtual void SortAuxDetSensitive(std::vector<geo::AuxDetSensitiveGeo>& adsgeo) const = 0;
+    virtual void SortCryostats(std::vector<geo::CryostatGeo>& cgeo) const = 0;
+    virtual void SortTPCs(std::vector<geo::TPCGeo>& tgeo) const = 0;
+    virtual void SortPlanes(std::vector<geo::PlaneGeo>& pgeo,
+                            geo::DriftDirection_t driftDir) const = 0;
+    virtual void SortWires(std::vector<geo::WireGeo>& wgeo) const = 0;
+    virtual void SortOpDets(std::vector<geo::OpDetGeo>& opdet) const;
   };
 
 }

--- a/larcorealg/Geometry/GeoObjectSorterStandard.cxx
+++ b/larcorealg/Geometry/GeoObjectSorterStandard.cxx
@@ -24,12 +24,11 @@ namespace geo{
 
   //----------------------------------------------------------------------------
   // Define sort order for cryostats in standard configuration
-  static bool sortAuxDetStandard(const AuxDetGeo* ad1, const AuxDetGeo* ad2)
+  static bool sortAuxDetStandard(const AuxDetGeo& ad1, const AuxDetGeo& ad2)
   {
-
     // sort based off of GDML name, assuming ordering is encoded
-    std::string ad1name = (ad1->TotalVolume())->GetName();
-    std::string ad2name = (ad2->TotalVolume())->GetName();
+    std::string const& ad1name = ad1.TotalVolume()->GetName();
+    std::string const& ad2name = ad2.TotalVolume()->GetName();
 
     // assume volume name is "volAuxDet##"
     int ad1Num = atoi( ad1name.substr( 9, ad1name.size()).c_str() );
@@ -41,29 +40,27 @@ namespace geo{
 
   //----------------------------------------------------------------------------
   // Define sort order for cryostats in standard configuration
-  static bool sortAuxDetSensitiveStandard(const AuxDetSensitiveGeo* ad1, const AuxDetSensitiveGeo* ad2)
+  static bool sortAuxDetSensitiveStandard(const AuxDetSensitiveGeo& ad1, const AuxDetSensitiveGeo& ad2)
   {
-
     // sort based off of GDML name, assuming ordering is encoded
-    std::string ad1name = (ad1->TotalVolume())->GetName();
-    std::string ad2name = (ad2->TotalVolume())->GetName();
+    std::string ad1name = (ad1.TotalVolume())->GetName();
+    std::string ad2name = (ad2.TotalVolume())->GetName();
 
     // assume volume name is "volAuxDetSensitive##"
     int ad1Num = atoi( ad1name.substr( 9, ad1name.size()).c_str() );
     int ad2Num = atoi( ad2name.substr( 9, ad2name.size()).c_str() );
 
     return ad1Num < ad2Num;
-
   }
 
   //----------------------------------------------------------------------------
   // Define sort order for cryostats in standard configuration
-  static bool sortCryoStandard(const CryostatGeo* c1, const CryostatGeo* c2)
+  static bool sortCryoStandard(const CryostatGeo& c1, const CryostatGeo& c2)
   {
     double xyz1[3] = {0.}, xyz2[3] = {0.};
     double local[3] = {0.};
-    c1->LocalToWorld(local, xyz1);
-    c2->LocalToWorld(local, xyz2);
+    c1.LocalToWorld(local, xyz1);
+    c2.LocalToWorld(local, xyz2);
 
     return xyz1[0] < xyz2[0];
   }
@@ -71,30 +68,28 @@ namespace geo{
 
   //----------------------------------------------------------------------------
   // Define sort order for tpcs in standard configuration.
-  static bool sortTPCStandard(const TPCGeo* t1, const TPCGeo* t2)
+  static bool sortTPCStandard(const TPCGeo& t1, const TPCGeo& t2)
   {
     double xyz1[3] = {0.};
     double xyz2[3] = {0.};
     double local[3] = {0.};
-    t1->LocalToWorld(local, xyz1);
-    t2->LocalToWorld(local, xyz2);
+    t1.LocalToWorld(local, xyz1);
+    t2.LocalToWorld(local, xyz2);
 
     // sort TPCs according to x
-    if(xyz1[0] < xyz2[0]) return true;
-
-    return false;
+    return xyz1[0] < xyz2[0];
   }
 
 
   //----------------------------------------------------------------------------
   // Define sort order for planes in standard configuration
-  static bool sortPlaneStandard(const PlaneGeo* p1, const PlaneGeo* p2)
+  static bool sortPlaneStandard(const PlaneGeo& p1, const PlaneGeo& p2)
   {
     double xyz1[3] = {0.};
     double xyz2[3] = {0.};
     double local[3] = {0.};
-    p1->LocalToWorld(local, xyz1);
-    p2->LocalToWorld(local, xyz2);
+    p1.LocalToWorld(local, xyz1);
+    p2.LocalToWorld(local, xyz2);
 
     // drift direction is negative, plane number increases in drift direction
     if(std::abs(xyz1[0]-xyz2[0]) > DistanceTol)
@@ -110,11 +105,12 @@ namespace geo{
 
 
   //----------------------------------------------------------------------------
-  bool sortWireStandard(WireGeo* w1, WireGeo* w2){
+  static bool sortWireStandard(WireGeo const& w1, WireGeo const& w2)
+  {
     double xyz1[3] = {0.};
     double xyz2[3] = {0.};
 
-    w1->GetCenter(xyz1); w2->GetCenter(xyz2);
+    w1.GetCenter(xyz1); w2.GetCenter(xyz2);
 
     //sort by z first
     if(std::abs(xyz1[2]-xyz2[2]) > DistanceTol)
@@ -130,50 +126,35 @@ namespace geo{
 
   //----------------------------------------------------------------------------
   GeoObjectSorterStandard::GeoObjectSorterStandard(fhicl::ParameterSet const&)
-  {
-  }
+  {}
 
   //----------------------------------------------------------------------------
-  GeoObjectSorterStandard::~GeoObjectSorterStandard()
-  {
-  }
-
-  //----------------------------------------------------------------------------
-  void GeoObjectSorterStandard::SortAuxDets(std::vector<geo::AuxDetGeo*> & adgeo) const
+  void GeoObjectSorterStandard::SortAuxDets(std::vector<geo::AuxDetGeo> & adgeo) const
   {
     std::sort(adgeo.begin(), adgeo.end(), sortAuxDetStandard);
-
-    return;
   }
 
   //----------------------------------------------------------------------------
-  void GeoObjectSorterStandard::SortAuxDetSensitive(std::vector<geo::AuxDetSensitiveGeo*> & adsgeo) const
+  void GeoObjectSorterStandard::SortAuxDetSensitive(std::vector<geo::AuxDetSensitiveGeo> & adsgeo) const
   {
     std::sort(adsgeo.begin(), adsgeo.end(), sortAuxDetSensitiveStandard);
-
-    return;
   }
 
   //----------------------------------------------------------------------------
-  void GeoObjectSorterStandard::SortCryostats(std::vector<geo::CryostatGeo*> & cgeo) const
+  void GeoObjectSorterStandard::SortCryostats(std::vector<geo::CryostatGeo> & cgeo) const
   {
     std::sort(cgeo.begin(), cgeo.end(), sortCryoStandard);
-
-    return;
   }
 
   //----------------------------------------------------------------------------
-  void GeoObjectSorterStandard::SortTPCs(std::vector<geo::TPCGeo*>  & tgeo) const
+  void GeoObjectSorterStandard::SortTPCs(std::vector<geo::TPCGeo>  & tgeo) const
   {
-
     std::sort(tgeo.begin(), tgeo.end(), sortTPCStandard);
-
-    return;
   }
 
   //----------------------------------------------------------------------------
-  void GeoObjectSorterStandard::SortPlanes(std::vector<geo::PlaneGeo*> & pgeo,
-					   geo::DriftDirection_t  const& driftDir) const
+  void GeoObjectSorterStandard::SortPlanes(std::vector<geo::PlaneGeo> & pgeo,
+                                           geo::DriftDirection_t  const driftDir) const
   {
     // sort the planes to increase in drift direction
     // The drift direction has to be set before this method is called.  It is set when
@@ -182,16 +163,12 @@ namespace geo{
     else if(driftDir == geo::kNegX) std::sort(pgeo.begin(),  pgeo.end(),  sortPlaneStandard);
     else if(driftDir == geo::kUnknownDrift)
       throw cet::exception("TPCGeo") << "Drift direction is unknown, can't sort the planes\n";
-
-    return;
   }
 
   //----------------------------------------------------------------------------
-  void GeoObjectSorterStandard::SortWires(std::vector<geo::WireGeo*> & wgeo) const
+  void GeoObjectSorterStandard::SortWires(std::vector<geo::WireGeo> & wgeo) const
   {
     std::sort(wgeo.begin(), wgeo.end(), sortWireStandard);
-
-    return;
   }
 
 }

--- a/larcorealg/Geometry/GeoObjectSorterStandard.h
+++ b/larcorealg/Geometry/GeoObjectSorterStandard.h
@@ -12,8 +12,7 @@
 
 #include "larcorealg/Geometry/GeoObjectSorter.h"
 #include "larcoreobj/SimpleTypesAndConstants/geo_types.h"  // for DriftDirec...
-
-namespace fhicl { class ParameterSet; }
+#include "fhiclcpp/fwd.h"
 
 namespace geo{
 
@@ -29,18 +28,14 @@ namespace geo{
   public:
 
     GeoObjectSorterStandard(fhicl::ParameterSet const& p);
-    ~GeoObjectSorterStandard();
 
-    void SortAuxDets        (std::vector<geo::AuxDetGeo*>          & adgeo)    const;
-    void SortAuxDetSensitive(std::vector<geo::AuxDetSensitiveGeo*> & adsgeo)   const;
-    void SortCryostats      (std::vector<geo::CryostatGeo*>        & cgeo)     const;
-    void SortTPCs     	    (std::vector<geo::TPCGeo*>      	   & tgeo)     const;
-    void SortPlanes   	    (std::vector<geo::PlaneGeo*>    	   & pgeo,
-		      	     geo::DriftDirection_t     	     const & driftDir) const;
-    void SortWires    	    (std::vector<geo::WireGeo*>     	   & wgeo)     const;
-
-  private:
-
+    void SortAuxDets        (std::vector<geo::AuxDetGeo>         & adgeo)    const override;
+    void SortAuxDetSensitive(std::vector<geo::AuxDetSensitiveGeo>& adsgeo)   const override;
+    void SortCryostats      (std::vector<geo::CryostatGeo>       & cgeo)     const override;
+    void SortTPCs           (std::vector<geo::TPCGeo>            & tgeo)     const override;
+    void SortPlanes         (std::vector<geo::PlaneGeo>          & pgeo,
+                             geo::DriftDirection_t                 driftDir) const override;
+    void SortWires          (std::vector<geo::WireGeo>           & wgeo)     const override;
   };
 
 }

--- a/larcorealg/Geometry/GeometryBuilder.h
+++ b/larcorealg/Geometry/GeometryBuilder.h
@@ -24,10 +24,7 @@
 #include <iterator> // std::back_inserter()
 #include <algorithm> // std::transform()
 
-
-
 namespace geo {
-
 
   /**
    * @brief Manages the extraction of LArSoft geometry information from ROOT.
@@ -54,20 +51,15 @@ namespace geo {
    */
   class GeometryBuilder {
 
-      public:
+  public:
 
     // --- BEGIN Data types ----------------------------------------------------
     /// Identification of a single node in ROOT geometry.
     using Path_t = geo::GeoNodePath;
 
-
-    /// Type of collection of geometry objects via (owning) pointers.
-    template <typename GeoObj>
-    using GeoColl_t = std::vector<GeoObj>;
-
     /// Type of direct collection of geometry objects.
     template <typename GeoObj>
-    using GeoPtrColl_t = std::vector<std::unique_ptr<GeoObj>>;
+    using GeoColl_t = std::vector<GeoObj>;
 
     // --- END Data types ------------------------------------------------------
 
@@ -84,7 +76,7 @@ namespace geo {
     /// @{
 
     /// Collection of cryostat information objects.
-    using Cryostats_t = GeoPtrColl_t<geo::CryostatGeo>;
+    using Cryostats_t = GeoColl_t<geo::CryostatGeo>;
 
     /**
      * @brief Looks for all cryostats under the specified path.
@@ -107,7 +99,7 @@ namespace geo {
     /// @{
 
     /// Collection of auxiliary detector information objects.
-    using AuxDets_t = GeoPtrColl_t<geo::AuxDetGeo>;
+    using AuxDets_t = GeoColl_t<geo::AuxDetGeo>;
 
     /**
      * @brief Looks for all auxiliary detectors under the specified path.
@@ -125,28 +117,9 @@ namespace geo {
     // --- END Auxiliary detector information ----------------------------------
 
 
-    // --- BEGIN Static utility methods ----------------------------------------
-    /**
-     * @brief Moves geometry objects of a indirect storage collection into a
-     *        direct storage one.
-     * @param src collection of pointers to geometry objects
-     * @return a collection of geometry objects
-     *
-     * The source collection `src`, contains pointers to the geometry objects,
-     * and the pointers own the objects.
-     * This function empties the source collection, its content moved into a
-     * collection of geometry objects. The returned collection directly owns
-     * the geometry objects.
-     */
-    template <typename GeoObj>
-    static GeoColl_t<GeoObj> moveToColl(GeoPtrColl_t<GeoObj>&& src);
-    template <typename GeoObj>
-    static GeoColl_t<GeoObj> moveToColl(GeoPtrColl_t<GeoObj>& src)
-      { return moveToColl(std::move(src)); }
-
     // --- END Static utility methods ------------------------------------------
 
-      protected:
+  protected:
 
     /// Custom implementation of `extractCryostats()`.
     virtual Cryostats_t doExtractCryostats(Path_t& path) = 0;
@@ -159,25 +132,5 @@ namespace geo {
 
 } // namespace geo
 
-
-//------------------------------------------------------------------------------
-//---  template implementation
-//------------------------------------------------------------------------------
-template <typename GeoObj>
-geo::GeometryBuilder::GeoColl_t<GeoObj> geo::GeometryBuilder::moveToColl
-  (GeoPtrColl_t<GeoObj>&& src)
-{
-  geo::GeometryBuilder::GeoColl_t<GeoObj> dest;
-  dest.reserve(src.size());
-  std::transform(
-    src.begin(), src.end(), std::back_inserter(dest),
-    [](auto& ptr){ return std::move(*(ptr.release())); }
-    );
-  src.clear();
-  return dest;
-} // geo::GeometryBuilder::moveToColl()
-
-
-//------------------------------------------------------------------------------
 
 #endif // LARCOREALG_GEOMETRY_GEOMETRYBUILDER_H

--- a/larcorealg/Geometry/GeometryBuilderStandard.cxx
+++ b/larcorealg/Geometry/GeometryBuilderStandard.cxx
@@ -61,7 +61,7 @@ geo::AuxDetGeo geo::GeometryBuilderStandard::doMakeAuxDet(Path_t& path) {
 
   return geo::AuxDetGeo(
     path.current(), path.currentTransformation<geo::TransformationMatrix>(),
-    geo::GeometryBuilder::moveToColl(extractAuxDetSensitive(path))
+    extractAuxDetSensitive(path)
     );
 
 } // geo::GeometryBuilderStandard::doMakeAuxDet()
@@ -107,8 +107,8 @@ geo::CryostatGeo geo::GeometryBuilderStandard::doMakeCryostat(Path_t& path) {
 
   return geo::CryostatGeo(
     path.current(), path.currentTransformation<geo::TransformationMatrix>(),
-    geo::GeometryBuilder::moveToColl(extractTPCs(path)),
-    geo::GeometryBuilder::moveToColl(extractOpDets(path))
+    extractTPCs(path),
+    extractOpDets(path)
     );
 
 } // geo::GeometryBuilderStandard::doMakeCryostat()
@@ -151,7 +151,7 @@ geo::GeometryBuilderStandard::TPCs_t geo::GeometryBuilderStandard::doExtractTPCs
 geo::TPCGeo geo::GeometryBuilderStandard::doMakeTPC(Path_t& path) {
   return geo::TPCGeo(
     path.current(), path.currentTransformation<geo::TransformationMatrix>(),
-     geo::GeometryBuilder::moveToColl(extractPlanes(path))
+     extractPlanes(path)
     );
 } // geo::GeometryBuilderStandard::doMakeTPC()
 
@@ -174,7 +174,7 @@ geo::GeometryBuilderStandard::doExtractPlanes(Path_t& path)
 geo::PlaneGeo geo::GeometryBuilderStandard::doMakePlane(Path_t& path) {
   return geo::PlaneGeo(
     path.current(), path.currentTransformation<geo::TransformationMatrix>(),
-     geo::GeometryBuilder::moveToColl(extractWires(path))
+     extractWires(path)
     );
 } // geo::GeometryBuilderStandard::doMakePlane()
 
@@ -259,18 +259,18 @@ template <
   bool (geo::GeometryBuilderStandard::*IsObj)(TGeoNode const&) const,
   ObjGeo (geo::GeometryBuilderStandard::*MakeObj)(geo::GeometryBuilder::Path_t&)
   >
-geo::GeometryBuilder::GeoPtrColl_t<ObjGeo>
+geo::GeometryBuilder::GeoColl_t<ObjGeo>
 geo::GeometryBuilderStandard::doExtractGeometryObjects(
   Path_t& path
 ) {
 
-  geo::GeometryBuilder::GeoPtrColl_t<ObjGeo> objs;
+  geo::GeometryBuilder::GeoColl_t<ObjGeo> objs;
 
   //
   // if this is a wire, we are set
   //
   if ((this->*IsObj)(path.current())) {
-    objs.emplace_back(std::make_unique<ObjGeo>((this->*MakeObj)(path)));
+    objs.push_back((this->*MakeObj)(path));
     return objs;
   }
 
@@ -293,4 +293,3 @@ geo::GeometryBuilderStandard::doExtractGeometryObjects(
 
 
 //------------------------------------------------------------------------------
-

--- a/larcorealg/Geometry/GeometryBuilderStandard.h
+++ b/larcorealg/Geometry/GeometryBuilderStandard.h
@@ -169,7 +169,7 @@ namespace geo {
     /// @name Auxiliary detector sensitive volume information
     /// @{
 
-    using AuxDetSensitive_t = GeoPtrColl_t<geo::AuxDetSensitiveGeo>;
+    using AuxDetSensitive_t = GeoColl_t<geo::AuxDetSensitiveGeo>;
 
     /**
      * @brief Looks for all auxiliary detectors under the specified path.
@@ -230,7 +230,7 @@ namespace geo {
     /// @name Optical detector information
     /// @{
 
-    using OpDets_t = GeoPtrColl_t<geo::OpDetGeo>;
+    using OpDets_t = GeoColl_t<geo::OpDetGeo>;
 
     /**
      * @brief Looks for all optical detectors under the specified path.
@@ -261,7 +261,7 @@ namespace geo {
     /// @name TPC information
     /// @{
 
-    using TPCs_t = GeoPtrColl_t<geo::TPCGeo>;
+    using TPCs_t = GeoColl_t<geo::TPCGeo>;
 
     /**
      * @brief Looks for all TPCs under the specified path.
@@ -294,7 +294,7 @@ namespace geo {
     /// @name Wire plane information
     /// @{
 
-    using Planes_t = GeoPtrColl_t<geo::PlaneGeo>;
+    using Planes_t = GeoColl_t<geo::PlaneGeo>;
 
     /**
      * @brief Looks for all wire planes under the specified path.
@@ -327,7 +327,7 @@ namespace geo {
     /// @name Wire information
     /// @{
 
-    using Wires_t = GeoPtrColl_t<geo::WireGeo>;
+    using Wires_t = GeoColl_t<geo::WireGeo>;
 
     /**
      * @brief Looks for all wires under the specified path.
@@ -420,7 +420,7 @@ namespace geo {
       bool (geo::GeometryBuilderStandard::*IsObj)(TGeoNode const&) const,
       ObjGeo (geo::GeometryBuilderStandard::*MakeObj)(Path_t&)
       >
-    GeoPtrColl_t<ObjGeo> doExtractGeometryObjects(Path_t& path);
+    GeoColl_t<ObjGeo> doExtractGeometryObjects(Path_t& path);
 
 
   }; // class GeometryBuilderStandard

--- a/larcorealg/Geometry/GeometryCore.cxx
+++ b/larcorealg/Geometry/GeometryCore.cxx
@@ -12,7 +12,6 @@
 // lar includes
 #include "larcoreobj/SimpleTypesAndConstants/PhysicalConstants.h" // util::pi<>
 #include "larcorealg/CoreUtils/DereferenceIterator.h" // lar::util::dereferenceIteratorLoop()
-#include "larcorealg/CoreUtils/SortByPointers.h"
 #include "larcorealg/Geometry/OpDetGeo.h"
 #include "larcorealg/Geometry/AuxDetGeo.h"
 #include "larcorealg/Geometry/AuxDetSensitiveGeo.h"
@@ -132,42 +131,30 @@ namespace geo {
     std::string gdmlfile, std::string rootfile,
     bool bForceReload /* = false*/
   ) {
-
-    fhicl::Table<geo::GeometryBuilderStandard::Config> builderConfig
+    fhicl::Table<geo::GeometryBuilderStandard::Config> const builderConfig
       (fBuilderParameters, { "tool_type" });
 
     // this is a wink to the understanding that we might be using a art-based
     // service provider configuration sprinkled with tools.
-    std::unique_ptr<geo::GeometryBuilder> builder
-      = std::make_unique<geo::GeometryBuilderStandard>(builderConfig());
-    LoadGeometryFile(gdmlfile, rootfile, *builder, bForceReload);
+    geo::GeometryBuilderStandard builder{builderConfig()};
+    LoadGeometryFile(gdmlfile, rootfile, builder, bForceReload);
   } // GeometryCore::LoadGeometryFile()
 
   //......................................................................
-  void GeometryCore::ClearGeometry() {
-
+  void GeometryCore::ClearGeometry()
+  {
     Cryostats().clear();
-
-    // auxiliary detectors
-    std::for_each(AuxDets().begin(), AuxDets().end(),
-      std::default_delete<AuxDetGeo>());
     AuxDets().clear();
-
-  } // GeometryCore::ClearGeometry()
+  }
 
 
   //......................................................................
-  void GeometryCore::SortGeometry(geo::GeoObjectSorter const& sorter) {
-
+  void GeometryCore::SortGeometry(geo::GeoObjectSorter const& sorter)
+  {
     mf::LogInfo("GeometryCore") << "Sorting volumes...";
 
     sorter.SortAuxDets(AuxDets());
-
-    //
-    // cryostats
-    //
-    util::SortByPointers(Cryostats(),
-      [&sorter](auto& coll){ sorter.SortCryostats(coll); });
+    sorter.SortCryostats(Cryostats());
 
     geo::CryostatID::CryostatID_t c = 0;
     for (geo::CryostatGeo& cryo: Cryostats())
@@ -294,9 +281,9 @@ namespace geo {
   {
     if( aid > NAuxDets() - 1)
       throw cet::exception("Geometry") << "Requested AuxDet index " << aid
-				       << " is out of range: " << NAuxDets();
+                                       << " is out of range: " << NAuxDets();
 
-    return AuxDets()[aid]->NSensitiveVolume();
+    return AuxDets()[aid].NSensitiveVolume();
   }
 
   //......................................................................
@@ -341,7 +328,7 @@ namespace geo {
     << ad
     << " does not exist\n";
 
-    return *(AuxDets()[ad]);
+    return AuxDets()[ad];
   }
 
 
@@ -550,7 +537,7 @@ namespace geo {
 
   //......................................................................
   const AuxDetGeo& GeometryCore::ChannelToAuxDet(std::string const& auxDetName,
-					     uint32_t    const& channel) const
+                                             uint32_t    const& channel) const
   {
     size_t adIdx = fChannelMapAlg->ChannelToAuxDet(AuxDets(), auxDetName, channel);
     return this->AuxDet(adIdx);
@@ -558,7 +545,7 @@ namespace geo {
 
   //......................................................................
   const AuxDetSensitiveGeo& GeometryCore::ChannelToAuxDetSensitive(std::string const& auxDetName,
-						      uint32_t    const& channel) const
+                                                      uint32_t    const& channel) const
   {
     auto idx = fChannelMapAlg->ChannelToSensitiveAuxDet(AuxDets(), auxDetName, channel);
     return this->AuxDet(idx.first).SensitiveVolume(idx.second);
@@ -1024,24 +1011,12 @@ namespace geo {
 
 
   //......................................................................
-  void GeometryCore::BuildGeometry(geo::GeometryBuilder& builder) {
-
+  void GeometryCore::BuildGeometry(geo::GeometryBuilder& builder)
+  {
     geo::GeoNodePath path{ gGeoManager->GetTopNode() };
-    Cryostats()
-      = geo::GeometryBuilder::moveToColl(builder.extractCryostats(path));
-    // channel mapping interface demands a vector of pointers to auxiliary
-    // detectors for several methods; and Gianluca is not going to fix that
-    // this time; so we waste some time and health in conversions.
-    auto auxDets =
-      geo::GeometryBuilder::moveToColl(builder.extractAuxiliaryDetectors(path));
-    std::transform(
-      auxDets.begin(), auxDets.end(), std::back_inserter(AuxDets()),
-      [](geo::AuxDetGeo& auxDet)
-        { return new geo::AuxDetGeo(std::move(auxDet)); }
-      );
-
-  } // GeometryCore::BuildGeometry()
-
+    Cryostats() = builder.extractCryostats(path);
+    AuxDets() = builder.extractAuxiliaryDetectors(path);
+  }
 
   //......................................................................
   //

--- a/larcorealg/Geometry/GeometryCore.cxx
+++ b/larcorealg/Geometry/GeometryCore.cxx
@@ -22,6 +22,7 @@
 #include "larcorealg/Geometry/geo_vectors_utils_TVector.h" // geo::vect
 
 // Framework includes
+#include "cetlib/pow.h"
 #include "cetlib_except/exception.h"
 #include "fhiclcpp/types/Table.h"
 #include "messagefacility/MessageLogger/MessageLogger.h"
@@ -48,11 +49,6 @@
 #include <numeric> // std::accumulate
 
 namespace geo {
-
-  template <typename T>
-  inline T sqr(T v) { return v * v; }
-
-
 
   //......................................................................
   lar::util::RealComparisons<geo::Length_t> GeometryCore::coordIs{ 1e-8 };
@@ -83,13 +79,12 @@ namespace geo {
 
   //......................................................................
   void GeometryCore::ApplyChannelMap
-    (std::shared_ptr<geo::ChannelMapAlg> pChannelMap)
+    (std::unique_ptr<geo::ChannelMapAlg> pChannelMap)
   {
     SortGeometry(pChannelMap->Sorter());
     UpdateAfterSorting(); // after channel mapping has sorted objects, set their IDs
     pChannelMap->Initialize(fGeoData);
-    fChannelMapAlg = pChannelMap;
-
+    fChannelMapAlg = move(pChannelMap);
   } // GeometryCore::ApplyChannelMap()
 
   //......................................................................
@@ -1493,7 +1488,7 @@ namespace geo {
     // note: we are not checking that w1 and w2 are not parallel.
     using geo::vect::dot;
     double const w1w2 = dot(w1, w2); // this is cos(angle), angle between wires
-    double const cscAngle2 = 1.0 / (1.0 - sqr(w1w2)); // this is 1/sin^2(angle)
+    double const cscAngle2 = 1.0 / (1.0 - cet::square(w1w2)); // this is 1/sin^2(angle)
     double const dcw1 = dot(dc, w1);
     double const dcw2 = dot(dc, w2);
     double const t = (dcw1 - (dcw2 * w1w2)) * cscAngle2;

--- a/larcorealg/Geometry/GeometryCore.h
+++ b/larcorealg/Geometry/GeometryCore.h
@@ -7,45 +7,33 @@
  *
  * Structure of the header:
  *
- *     namespace geo {
+ *   namespace geo {
  *
- *       // forward class declarations
+ *     // forward class declarations
  *
- *       namespace details {
+ *     namespace details {
  *
- *         // geometry iterator base class
- *
- *       }
- *
- *       // geometry iterators declaration
- *       //  - cryostat_id_iterator
- *       //  - TPC_id_iterator
- *       //  - plane_id_iterator
- *       //  - wire_id_iterator
- *       //  - TPCset_id_iterator
- *       //  - ROP_id_iterator
- *
- *       // GeometryData_t definition (part of GeometryCore)
- *
- *       // GeometryCore declaration
+ *       // geometry iterator base class
  *
  *     }
  *
+ *     // geometry iterators declaration
+ *     //  - cryostat_id_iterator
+ *     //  - TPC_id_iterator
+ *     //  - plane_id_iterator
+ *     //  - wire_id_iterator
+ *     //  - TPCset_id_iterator
+ *     //  - ROP_id_iterator
  *
+ *     // GeometryData_t definition (part of GeometryCore)
  *
- * Revised <seligman@nevis.columbia.edu> 29-Jan-2009
- *         Revise the class to make it into more of a general detector interface
- * Revised <petrillo@fnal.gov> 27-Apr-2015
- *         Factorization into a framework-independent GeometryCore.h and a
- *         art framework interface
- * Revised <petrillo@fnal.gov> 30-Apr-2015
- *         Redesign of the iterators
- * Revised <petrillo@fnal.gov> 28-Jun-2015
- *         Added interface for readout mapping
+ *     // GeometryCore declaration
+ *   }
+ *
  */
+
 #ifndef LARCOREALG_GEOMETRY_GEOMETRYCORE_H
 #define LARCOREALG_GEOMETRY_GEOMETRYCORE_H
-
 
 // LArSoft libraries
 #include "larcorealg/Geometry/GeoObjectSorter.h"
@@ -85,24 +73,20 @@
 #include <iterator> // std::forward_iterator_tag
 #include <type_traits> // std::is_base_of<>
 
-
 // ROOT class prototypes
 class TGeoManager;
 class TGeoNode;
 class TGeoVolume;
 class TGeoMaterial;
 
-
 /// Namespace collecting geometry-related classes utilities
 namespace geo {
-
 
   // Forward declarations within namespace.
   class AuxDetGeo;
   class AuxDetSensitiveGeo;
   class OpDetGeo;
   class GeometryCore;
-
 
   //
   // iterators
@@ -173,8 +157,8 @@ namespace geo {
       using LocalID_t = geo::CryostatID; ///< type of the ID we change
       static_assert(std::is_base_of<LocalID_t, GEOID>::value,
         "template type GEOID is not a LocalID_t");
-      
-      
+
+
       /// @name Iterator traits
       /// @{
       using difference_type = std::ptrdiff_t;
@@ -183,7 +167,7 @@ namespace geo {
       using pointer  = value_type const*;
       using iterator_category = std::input_iterator_tag;
       /// @}
-      
+
 
       /// Default constructor; effect not defined: assign to it before using!
       cryostat_id_iterator_base() {}
@@ -331,7 +315,7 @@ namespace geo {
       using upper_iterator::begin_pos;
       using upper_iterator::end_pos;
 
-      
+
       /// @name Iterator traits
       /// @{
       using difference_type = std::ptrdiff_t;
@@ -340,8 +324,8 @@ namespace geo {
       using pointer  = value_type const*;
       using iterator_category = std::input_iterator_tag;
       /// @}
-      
-      
+
+
       /// Default constructor; effect not defined: assign to it before using!
       TPC_id_iterator_base() {}
 
@@ -479,7 +463,7 @@ namespace geo {
       using upper_iterator::begin_pos;
       using upper_iterator::end_pos;
 
-      
+
       /// @name Iterator traits
       /// @{
       using difference_type = std::ptrdiff_t;
@@ -488,8 +472,8 @@ namespace geo {
       using pointer  = value_type const*;
       using iterator_category = std::input_iterator_tag;
       /// @}
-      
-      
+
+
       /// Default constructor; effect not defined: assign to it before using!
       plane_id_iterator_base() {}
 
@@ -627,7 +611,7 @@ namespace geo {
       using upper_iterator::begin_pos;
       using upper_iterator::end_pos;
 
-      
+
       /// @name Iterator traits
       /// @{
       using difference_type = std::ptrdiff_t;
@@ -636,8 +620,8 @@ namespace geo {
       using pointer  = value_type const*;
       using iterator_category = std::input_iterator_tag;
       /// @}
-      
-      
+
+
       /// Default constructor; effect not defined: assign to it before using!
       wire_id_iterator_base() {}
 
@@ -813,7 +797,7 @@ namespace geo {
       /// Geometry class pointed by the iterator
       using Element_t = typename std::remove_pointer<ElementPtr_t>::type;
 
-      
+
       /// @name Iterator traits
       /// @{
       using difference_type = std::ptrdiff_t;
@@ -822,8 +806,8 @@ namespace geo {
       using pointer  = value_type const*;
       using iterator_category = std::forward_iterator_tag;
       /// @}
-      
-      
+
+
       /// Default constructor; effect not defined: assign to it before using!
       geometry_element_iterator() = default;
 
@@ -963,8 +947,8 @@ namespace geo {
       using upper_iterator::undefined_pos;
       using upper_iterator::begin_pos;
       using upper_iterator::end_pos;
-      
-      
+
+
       /// @name Iterator traits
       /// @{
       using difference_type = std::ptrdiff_t;
@@ -973,7 +957,7 @@ namespace geo {
       using pointer  = value_type const*;
       using iterator_category = std::input_iterator_tag;
       /// @}
-      
+
 
       /// Default constructor; effect not defined: assign to it before using!
       TPCset_id_iterator_base() {}
@@ -1114,8 +1098,8 @@ namespace geo {
       using upper_iterator::undefined_pos;
       using upper_iterator::begin_pos;
       using upper_iterator::end_pos;
-      
-      
+
+
       /// @name Iterator traits
       /// @{
       using difference_type = std::ptrdiff_t;
@@ -1124,7 +1108,7 @@ namespace geo {
       using pointer  = value_type const*;
       using iterator_category = std::input_iterator_tag;
       /// @}
-      
+
 
       /// Default constructor; effect not defined: assign to it before using!
       ROP_id_iterator_base() = default;
@@ -4506,7 +4490,7 @@ namespace geo {
      * @param c ID of the cryostat the detector is in
      *
      * This name is defined in the geometry (GDML) description.
-	  *
+          *
      * @todo Change to use CryostatID
      */
     std::string OpDetGeoName(unsigned int c = 0) const;
@@ -4648,11 +4632,11 @@ namespace geo {
                                                         size_t     & sv) const;
 
     const AuxDetGeo&         ChannelToAuxDet(std::string const& auxDetName,
-					     uint32_t    const& channel) const; // return the AuxDetGeo for the given detector
+                                             uint32_t    const& channel) const; // return the AuxDetGeo for the given detector
                                                                                 // name and channel
 
     const AuxDetSensitiveGeo& ChannelToAuxDetSensitive(std::string const& auxDetName,
-						       uint32_t    const& channel) const; // return the AuxDetSensitiveGeo for the given
+                                                       uint32_t    const& channel) const; // return the AuxDetSensitiveGeo for the given
 
     /// @} Auxiliary detectors access and information
 
@@ -5030,53 +5014,7 @@ namespace geo {
       >
     IterateTPCsetIDs(geo::CryostatID const& cid) const { return { this, cid }; }
 
-
-#if 0
-    //
-    // single object features
-    //
-
-    /**
-     * @brief Returns the half width of the specified TPC set (x direction)
-     * @param tpcsetid ID of the TPC set
-     * @return the value of the half width of the specified TPC set
-     *
-     * @todo what happens if it does not exist?
-     */
-    double TPCsetHalfWidth(readout::TPCsetID const& tpcsetid) const;
-
-    /**
-     * @brief Returns the half height of the specified TPC set (y direction)
-     * @param tpcsetid ID of the TPC set
-     * @return the value of the half height of the specified TPC set
-     *
-     * @todo what happens if it does not exist?
-     */
-    double TPCsetHalfHeight(readout::TPCsetID const& tpcsetid) const;
-
-    /**
-     * @brief Returns the length of the specified TPC set (z direction)
-     * @param tpcsetid ID of the TPC set
-     * @return the value of the length of the specified TPC set
-     *
-     * @todo what happens if it does not exist?
-     */
-    double TPCsetLength(readout::TPCsetID const& tpcsetid) const;
-
-
-    /**
-     * @brief Returns the centre of side of the detector facing the beam
-     * @param tpcsetid ID of the TPC set
-     * @return vector of the position of centre of TPC set face toward the beam
-     */
-    geo::Point_t GetTPCsetFrontFaceCenter
-      (readout::TPCsetID const& tpcsetid) const;
-
-
-#endif // 0
-
     /// @} TPC set information
-
 
 
     /// @name Readout plane information
@@ -5545,8 +5483,8 @@ namespace geo {
 
     // cached values
     std::set<geo::View_t> allViews; ///< All views in the detector.
-    
-    
+
+
     std::vector<TGeoNode const*> FindDetectorEnclosure
       (std::string const& name = "volDetEnclosure") const;
 

--- a/larcorealg/Geometry/GeometryCore.h
+++ b/larcorealg/Geometry/GeometryCore.h
@@ -1459,9 +1459,7 @@ namespace geo {
    *    is forbidden and it would yield undefined behaviour (expected to be
    *    catastrophic)
    * 4. acquire the channel mapping algorithm with
-   *    GeometryCore::ApplyChannelMap(); at this point, the ChannelMapAlg object
-   *    is asked to initialize itself and to perform whatever modifications to
-   *    the geometry provider is needed.
+   *    GeometryCore::ApplyChannelMap().
    *
    * Step 3 (creation of the channel mapping algorithm object) can be performed
    * at any time before step 4, provided that no GeometryCore instance is needed
@@ -5498,25 +5496,18 @@ namespace geo {
      * @see LoadGeometryFile()
      *
      * The specified channel mapping is used with this geometry.
-     * The algorithm object is asked and allowed to make the necessary
-     * modifications to the geometry description.
      * These modifications typically involve some resorting of the objects.
-     *
-     * The ownership of the algorithm object is shared, usually with a calling
-     * framework: we maintain it alive as long as we need it (and no other code
-     * can delete it), and we delete it only if no other code is sharing the
-     * ownership.
      *
      * This method needs to be called after LoadGeometryFile() to complete the
      * geometry initialization.
      */
-    void ApplyChannelMap(std::shared_ptr<geo::ChannelMapAlg> pChannelMap);
+    void ApplyChannelMap(std::unique_ptr<geo::ChannelMapAlg> pChannelMap);
     /// @}
 
 
   protected:
     /// Sets the detector name
-    void SetDetectorName(std::string new_name) { fDetectorName = new_name; }
+    void SetDetectorName(std::string const& new_name) { fDetectorName = new_name; }
 
     /// Returns the object handling the channel map
     geo::ChannelMapAlg const* ChannelMap() const
@@ -5549,7 +5540,7 @@ namespace geo {
     /// Configuration for the geometry builder
     /// (needed since builder is created after construction).
     fhicl::ParameterSet fBuilderParameters;
-    std::shared_ptr<const geo::ChannelMapAlg> fChannelMapAlg;
+    std::unique_ptr<const geo::ChannelMapAlg> fChannelMapAlg;
                                     ///< Object containing the channel to wire mapping
 
     // cached values

--- a/larcorealg/Geometry/GeometryData.h
+++ b/larcorealg/Geometry/GeometryData.h
@@ -4,7 +4,7 @@
  * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
  * @see    `larcorealg/Geometry/GeometryCore.h`
  * @ingroup Geometry
- * 
+ *
  * This is a header-only library.
  */
 
@@ -20,20 +20,20 @@
 
 
 namespace geo {
-  
+
   /*
    * To decouple the channel mapping algorithm from `geo::GeometryCore`,
    * this data structure, which is in fact the core data of `geo::GeometryCore`,
    * is detached and included by both.
    */
-  
+
   /// Data in the geometry description.
   struct GeometryData_t {
 
     /// Type of list of cryostats.
     using CryostatList_t = std::vector<geo::CryostatGeo>;
     /// Type of list of auxiliary detectors
-    using AuxDetList_t = std::vector<geo::AuxDetGeo*>;
+    using AuxDetList_t = std::vector<geo::AuxDetGeo>;
 
     CryostatList_t cryostats; ///< The detector cryostats.
     AuxDetList_t   auxDets;   ///< The auxiliary detectors.

--- a/larcorealg/Geometry/OpDetGeo.cxx
+++ b/larcorealg/Geometry/OpDetGeo.cxx
@@ -35,7 +35,6 @@ namespace geo{
     fOpDetNode = &node;
 
     fCenter = toWorldCoords(geo::origin<LocalPoint_t>());
-
   }
 
   //......................................................................

--- a/larcorealg/Geometry/OpDetGeo.cxx
+++ b/larcorealg/Geometry/OpDetGeo.cxx
@@ -20,12 +20,6 @@
 // C/C++ standard libraries
 #include <cmath>
 
-
-namespace {
-  template <typename T>
-  inline T sqr(T v) { return v*v; }
-} // local namespace
-
 namespace geo{
 
   //-----------------------------------------

--- a/larcorealg/Geometry/PlaneGeo.cxx
+++ b/larcorealg/Geometry/PlaneGeo.cxx
@@ -12,7 +12,6 @@
 #include "larcorealg/Geometry/WireGeo.h"
 #include "larcorealg/Geometry/geo_vectors_utils.h" // geo::vect::convertTo()
 #include "larcorealg/CoreUtils/RealComparisons.h"
-#include "larcorealg/CoreUtils/SortByPointers.h"
 #include "larcoreobj/SimpleTypesAndConstants/PhysicalConstants.h" // util::pi()
 
 // Framework includes
@@ -524,10 +523,7 @@ namespace geo{
   // sort the WireGeo objects
   void PlaneGeo::SortWires(geo::GeoObjectSorter const& sorter )
   {
-    // the sorter interface requires a vector of pointers;
-    // sorting is faster, but some gymnastics is required:
-    util::SortByPointers
-      (fWire, [&sorter](auto& coll){ sorter.SortWires(coll); });
+    sorter.SortWires(fWire);
   }
 
 
@@ -934,11 +930,11 @@ namespace geo{
     // pick long wires around the center of the detector,
     // so that their coordinates are defined with better precision
     assert(Nwires() > 1);
-    
+
     auto const iWire = Nwires() / 2;
-    
+
     fWirePitch = geo::WireGeo::WirePitch(Wire(iWire - 1), Wire(iWire));
-    
+
   } // PlaneGeo::UpdateWirePitch()
 
   //......................................................................
@@ -1210,9 +1206,9 @@ namespace geo{
     fCenter = GetBoxCenter<geo::Point_t>();
 
     DriftPoint(fCenter, DistanceFromPlane(fCenter));
-    
+
     geo::vect::round0(fCenter, 1e-7); // round dimensions less than 1 nm to 0
-    
+
     fDecompFrame.SetOrigin(fCenter); // equivalent to GetCenter() now
 
   } // PlaneGeo::UpdateWirePlaneCenter()

--- a/larcorealg/Geometry/PlaneGeo.cxx
+++ b/larcorealg/Geometry/PlaneGeo.cxx
@@ -16,6 +16,7 @@
 
 // Framework includes
 #include "messagefacility/MessageLogger/MessageLogger.h"
+#include "cetlib/pow.h"
 #include "cetlib_except/exception.h"
 
 // ROOT includes
@@ -59,15 +60,8 @@ namespace {
     return value + symmetricCapDelta(value, limit);
 
   } // symmetricCap()
-  
-  
-  /// Returns the square of `v`.
-  template <typename T>
-  T sqr(T v) { return v * v; }
-  
-  
-} // local namespace
 
+} // local namespace
 
 
 namespace geo{
@@ -711,23 +705,23 @@ namespace geo{
     (WireCoordProjection_t const& projDir) const
   {
     assert(lar::util::Vector2DComparison{1e-6}.nonZero(projDir));
-    return std::sqrt(sqr(projDir.X() / projDir.Y()) + 1.0) * fWirePitch;
+    return std::sqrt(cet::square(projDir.X() / projDir.Y()) + 1.0) * fWirePitch;
   } // PlaneGeo::InterWireProjectedDistance()
-  
-  
+
+
   //......................................................................
   double PlaneGeo::InterWireDistance(geo::Vector_t const& dir) const {
     // the secondary component of the wire decomposition basis is wire coord.
     double const r = dir.R();
     assert(r >= 1.e-6);
-    
+
     double const absWireCoordProj
       = std::abs(fDecompWire.VectorSecondaryComponent(dir));
     return r / absWireCoordProj * fWirePitch;
-    
+
   } // PlaneGeo::InterWireDistance()
-  
-  
+
+
   //......................................................................
   double PlaneGeo::ThetaZ() const { return FirstWire().ThetaZ(); }
 

--- a/larcorealg/Geometry/StandaloneGeometrySetup.cxx
+++ b/larcorealg/Geometry/StandaloneGeometrySetup.cxx
@@ -29,7 +29,7 @@ std::unique_ptr<geo::GeometryCore>
 lar::standalone::SetupGeometryWithChannelMapping
   (
     fhicl::ParameterSet const& pset,
-    std::shared_ptr<geo::ChannelMapAlg> channelMap
+    std::unique_ptr<geo::ChannelMapAlg> channelMap
   )
 {
   auto const bForceReload = true;
@@ -98,11 +98,10 @@ lar::standalone::SetupGeometryWithChannelMapping
   // create and apply channel mapping
   //
 
-  geom->ApplyChannelMap(channelMap);
+  geom->ApplyChannelMap(move(channelMap));
 
   return geom;
 } // lar::standalone::SetupGeometryWithChannelMapping()
 
 
 //------------------------------------------------------------------------------
-

--- a/larcorealg/Geometry/StandaloneGeometrySetup.h
+++ b/larcorealg/Geometry/StandaloneGeometrySetup.h
@@ -23,11 +23,9 @@
 // C/C++ standard libraries
 #include <string>
 #include <set>
-#include <memory> // std::make_unique(), std::make_shared()
+#include <memory> // std::make_unique()
 
-namespace lar {
-
-  namespace standalone {
+namespace lar::standalone {
 
     // --- BEGIN Geometry group ------------------------------------------------
     /// @ingroup Geometry
@@ -45,7 +43,7 @@ namespace lar {
      * specified channel mapping.
      * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
      * // create a channel mapping algorithm
-     * std::make_shared<geo::StandardChannelMapAlg> channelMap
+     * std::make_unique<geo::StandardChannelMapAlg> channelMap
      *   (pset.get<fhicl::ParameterSet>("SortingParameters"));
      *
      * std::unique_ptr<geo::GeometryCore> geom
@@ -89,11 +87,9 @@ namespace lar {
      *   `geo::ChannelMapAlg`); its content is dependent on the chosen
      *   implementation of `geo::ChannelMapAlg`
      */
-    std::unique_ptr<geo::GeometryCore> SetupGeometryWithChannelMapping(
-      fhicl::ParameterSet const& pset,
-      std::shared_ptr<geo::ChannelMapAlg> channelMap
-      );
-
+    std::unique_ptr<geo::GeometryCore>
+    SetupGeometryWithChannelMapping(fhicl::ParameterSet const& pset,
+                                    std::unique_ptr<geo::ChannelMapAlg> channelMap);
 
     //--------------------------------------------------------------------------
     /**
@@ -130,33 +126,28 @@ namespace lar {
      *
      */
     template <typename ChannelMapClass, typename... Args>
-    std::unique_ptr<geo::GeometryCore> SetupGeometry
-      (fhicl::ParameterSet const& pset, Args&&... args);
+    std::unique_ptr<geo::GeometryCore>
+    SetupGeometry(fhicl::ParameterSet const& pset, Args&&... args);
 
     //--------------------------------------------------------------------------
 
     // --- END Geometry group --------------------------------------------------
     /// @}
 
-  } // namespace standalone
-} // namespace lar
+} // namespace lar::standalone
 
 
 //------------------------------------------------------------------------------
 //---  template implementation
 //---
 template <typename ChannelMapClass, typename... Args>
-std::unique_ptr<geo::GeometryCore> lar::standalone::SetupGeometry
-  (fhicl::ParameterSet const& pset, Args&&... args)
+std::unique_ptr<geo::GeometryCore>
+lar::standalone::SetupGeometry(fhicl::ParameterSet const& pset, Args&&... args)
 {
-  auto SortingParameters
-    = pset.get<fhicl::ParameterSet>("SortingParameters", fhicl::ParameterSet());
-
-  auto channelMap = std::make_shared<ChannelMapClass>
-    (SortingParameters, std::forward<Args>(args)...);
-
-  return SetupGeometryWithChannelMapping(pset, channelMap);
-
+  auto const SortingParameters = pset.get<fhicl::ParameterSet>("SortingParameters", {});
+  auto channelMap = std::make_unique<ChannelMapClass>(SortingParameters,
+                                                      std::forward<Args>(args)...);
+  return SetupGeometryWithChannelMapping(pset, move(channelMap));
 } // lar::standalone::SetupGeometry()
 
 //------------------------------------------------------------------------------

--- a/test/CoreUtils/CMakeLists.txt
+++ b/test/CoreUtils/CMakeLists.txt
@@ -20,8 +20,8 @@ cet_test( NumericUtils_test USE_BOOST_UNIT )
 cet_test( DereferenceIterator_test USE_BOOST_UNIT )
 cet_test( DumpUtils_test
   LIBRARIES
-    ${ROOT_CORE}
-    ${ROOT_PHYSICS}
+    ROOT::Core
+    ROOT::Physics
   USE_BOOST_UNIT
   )
 cet_test( SortByPointers_test USE_BOOST_UNIT )

--- a/test/Geometry/CMakeLists.txt
+++ b/test/Geometry/CMakeLists.txt
@@ -20,7 +20,6 @@ cet_make_library( LIBRARY_NAME GeometryTestLib
                         larcorealg_TestUtils
                         canvas
                         ${MF_MESSAGELOGGER}
-                        
                         ${FHICLCPP}
                         cetlib cetlib_except
                         ${Boost_UNIT_TEST_FRAMEWORK_LIBRARY}
@@ -36,7 +35,6 @@ cet_test(geometry_iterator_test
   LIBRARIES larcorealg_Geometry
             GeometryTestLib
             ${MF_MESSAGELOGGER}
-            
             ${FHICLCPP}
             cetlib cetlib_except
   USE_BOOST_UNIT
@@ -51,7 +49,6 @@ cet_test(geometry_geoid_test
   LIBRARIES larcorealg_Geometry
             GeometryTestLib
             ${MF_MESSAGELOGGER}
-            
             ${FHICLCPP}
             cetlib cetlib_except
   USE_BOOST_UNIT
@@ -67,7 +64,6 @@ cet_test(geometry_test
   LIBRARIES larcorealg_Geometry
             GeometryTestLib
             ${MF_MESSAGELOGGER}
-            
             ${FHICLCPP}
             cetlib cetlib_except
 )
@@ -80,7 +76,6 @@ cet_test(geometry_loader_test
   LIBRARIES larcorealg_Geometry
             GeometryTestLib
             ${MF_MESSAGELOGGER}
-            
             ${FHICLCPP}
             cetlib cetlib_except
 )
@@ -93,7 +88,6 @@ cet_test(geometry_iterator_loop_test
   LIBRARIES larcorealg_Geometry
             GeometryTestLib
             ${MF_MESSAGELOGGER}
-            
             ${FHICLCPP}
             cetlib cetlib_except
 )
@@ -105,7 +99,6 @@ cet_test(geometry_standardchannelmapping_test
   LIBRARIES larcorealg_Geometry
             GeometryTestLib
             ${MF_MESSAGELOGGER}
-            
             ${FHICLCPP}
             cetlib cetlib_except
   USE_BOOST_UNIT
@@ -120,7 +113,6 @@ cet_test(geometry_thirdplaneslope_test
   SOURCES geometry_thirdplaneslope_test.cxx
   LIBRARIES larcorealg_Geometry
             ${MF_MESSAGELOGGER}
-            
             ${FHICLCPP}
             cetlib cetlib_except
   USE_BOOST_UNIT
@@ -151,7 +143,6 @@ cet_test(driftvolumes_test
   TEST_ARGS ./test_geometry.fcl
   LIBRARIES larcorealg_Geometry
             ${MF_MESSAGELOGGER}
-            
             ${FHICLCPP}
             cetlib cetlib_except
   USE_BOOST_UNIT
@@ -187,7 +178,7 @@ if( NOT mrb_build_dir )
   set_tests_properties( geometry_iterator_test geometry_test geometry_loader_test
                         geometry_iterator_loop_test geometry_standardchannelmapping_test
                         geometry_geoid_test geometry_thirdplaneslope_test
-                        PROPERTIES ENVIRONMENT 
+                        PROPERTIES ENVIRONMENT
                         "FHICL_FILE_PATH=.:${CMAKE_BINARY_DIR}/job;FW_SEARCH_PATH=${CMAKE_BINARY_DIR}/gdml" )
 endif()
 

--- a/test/Geometry/CMakeLists.txt
+++ b/test/Geometry/CMakeLists.txt
@@ -2,9 +2,9 @@ cet_enable_asserts()
 
 cet_test( geo_vectors_utils_test
   LIBRARIES
-    ${ROOT_CORE}
-    ${ROOT_PHYSICS}
-    ${ROOT_GENVECTOR}
+    ROOT::Core
+    ROOT::Physics
+    ROOT::GenVector
   USE_BOOST_UNIT
   )
 
@@ -133,9 +133,9 @@ cet_test(geometry_thirdplaneslope_test
 cet_test(Decomposer_test
   SOURCES Decomposer_test.cxx
   LIBRARIES
-    ${ROOT_PHYSICS}
-    ${ROOT_GENVECTOR}
-    ${ROOT_CORE} # TVersionCheck
+    ROOT::Physics
+    ROOT::GenVector
+    ROOT::Core # TVersionCheck
   USE_BOOST_UNIT
   )
 

--- a/test/Geometry/GeometryTestAlg.cxx
+++ b/test/Geometry/GeometryTestAlg.cxx
@@ -394,12 +394,12 @@ namespace geo{
       << "\nWire length "        << 2.*testWire.HalfL()
       << "\nWire Rmin  "         << testWire.RMin()
       ;
-    
+
     if (fComputeMass) {
       log
         << "\nTotal mass "         << geom->TotalMass();
     }
-    
+
     log
       << "\nNumber of views "    << geom->Nviews()
       << "\nNumber of channels " << geom->Nchannels()
@@ -678,10 +678,10 @@ namespace geo{
     mf::LogVerbatim("GeometryTest") << "There are " << geom->Ncryostats() << " cryostats in the detector";
 
     for(geo::CryostatGeo const& cryo: geom->IterateCryostats()) {
-      
+
       {
         mf::LogVerbatim log("GeometryTest");
-        
+
         log
           << "\n\tCryostat " << cryo.ID()
           <<   " " << cryo.Volume()->GetName()
@@ -700,7 +700,7 @@ namespace geo{
           <<   "  -z:" << cryo.MinZ() << " +z:" << cryo.MaxZ()
           ;
       }
-      
+
       // pick a position in the middle of the cryostat in the world coordinates
       double const worldLoc[3]
         = { cryo.CenterX(), cryo.CenterY(), cryo.CenterZ() };
@@ -3051,7 +3051,7 @@ namespace geo{
 
   //......................................................................
   void GeometryTestAlg::testInterWireProjectedDistance() const {
-    
+
     /*
      * For each wire plane:
      *  * we pick some projected directions; for each one:
@@ -3060,16 +3060,16 @@ namespace geo{
      *     * add some arbitrary component on the drift direction; for each one:
      *       * check that the projected distance is as expected
      *       * check that the 3D distance is as expected
-     * 
+     *
      * We do not test directions parallel to the wires because they get
      * numerically unstable and the expectation may potentially differ a lot
      * being calculated with a different procedure.
      */
-    
+
     constexpr lar::util::RealComparisons cmp { 1e-4 };
-    
+
     static double const V3 = std::sqrt(3.0);
-    
+
     // BUG the deduction guide for std::array seems not to be implemented yet
     //     in Clang 5.0.0
     // BUG the double brace syntax is required to work around clang bug 21629
@@ -3125,21 +3125,21 @@ namespace geo{
               ;
             ++nErrors;
           } // if unexpected result
-          
+
           // this is how much we needed to expand the test direction vector
           // (happens to work for the special case expected = 0 too)
           double const dScale = expected / testProj.R();
-          
+
           //
           // test a 3D direction
           //
-          
+
           auto const baseDir
             = plane.ComposeVector<geo::Vector_t>(0.0, testProj);
-          
+
           for (double const driftOffset: testDriftOffsets) {
             auto const testDir = baseDir + driftOffset * normalDir;
-            
+
             double const interWire = plane.InterWireProjectedDistance(testDir);
             if (cmp.nonEqual(interWire, expected)) {
               mf::LogProblem("") << "ERROR: on plane " << plane.ID()
@@ -3165,26 +3165,26 @@ namespace geo{
                 ;
               ++nErrors;
             } // if unexpected result
-            
-            
-            
+
+
+
           } // for drifts
-          
+
         } // for dirL, dirW and scale
-        
+
       } // for all test projection directions
-      
+
     } // for all planes
-    
-    
+
+
     if (nErrors > 0U) {
       throw cet::exception("InterWireProjectedDistance")
         << "unexpected distances in " << nErrors << " tests!";
     } // end loop over planes
-  
+
   } // GeometryTestAlg::testInterWireProjectedDistance()
-  
-  
+
+
   //......................................................................
   void GeometryTestAlg::testPlanePitch()
   {

--- a/test/Geometry/geometry_unit_test_base.h
+++ b/test/Geometry/geometry_unit_test_base.h
@@ -349,14 +349,12 @@ namespace testing {
     //
     // create the new channel map
     //
-    fhicl::ParameterSet SortingParameters
+    auto const SortingParameters
       = ProviderConfig.get<fhicl::ParameterSet>("SortingParameters", {});
-    std::shared_ptr<geo::ChannelMapAlg> pChannelMap
-      (new ChannelMapClass(SortingParameters));
 
     // connect the channel map with the geometry, that shares ownsership
     // (we give up ours at the end of this method)
-    new_geom->ApplyChannelMap(pChannelMap);
+    new_geom->ApplyChannelMap(std::make_unique<ChannelMapClass>(SortingParameters));
 
     return new_geom;
   } // GeometryTesterEnvironment<>::CreateNewGeometry()


### PR DESCRIPTION
This is part of a coordinated set of PRs that accomplish two tasks:

- Switching to geometry collections that own by value instead of by pointer
- Switching the (AuxDet) geometry systems to be thread-safe within a run

There are breaking changes associated with this PR, and they will be presented at the next LArSoft coordination meeting.