### PR TITLE
Add a bit of information to geometry dump.

### DIFF
--- a/larcorealg/Geometry/CMakeLists.txt
+++ b/larcorealg/Geometry/CMakeLists.txt
@@ -2,6 +2,7 @@ cet_make(
   SUBDIRS
     "details"
   LIBRARIES
+          larcoreobj_SimpleTypesAndConstants
           ${MF_MESSAGELOGGER}
           ${FHICLCPP}
           cetlib

--- a/larcorealg/Geometry/GeometryCore.cxx
+++ b/larcorealg/Geometry/GeometryCore.cxx
@@ -576,19 +576,6 @@ namespace geo {
 
 
   //......................................................................
-  std::string GeometryCore::SignalTypeName(geo::SigType_t sigType) {
-    switch (sigType) {
-      case kInduction: return "induction";
-      case kCollection: return "collection";
-      case kMysteryType: return "unknown";
-    } // switch
-    throw cet::exception("GeometryCore")
-      << "SignalTypeName(): Logic error: unexpected signal type "
-      << static_cast<int>(sigType) << "\n";
-  } // GeometryCore::SignalTypeName()
-  
-  
-  //......................................................................
   View_t GeometryCore::View(raw::ChannelID_t const channel) const {
     return (channel == raw::InvalidChannelID)
       ? geo::kUnknown: View(ChannelToROP(channel));

--- a/larcorealg/Geometry/GeometryCore.cxx
+++ b/larcorealg/Geometry/GeometryCore.cxx
@@ -576,6 +576,19 @@ namespace geo {
 
 
   //......................................................................
+  std::string GeometryCore::SignalTypeName(geo::SigType_t sigType) {
+    switch (sigType) {
+      case kInduction: return "induction";
+      case kCollection: return "collection";
+      case kMysteryType: return "unknown";
+    } // switch
+    throw cet::exception("GeometryCore")
+      << "SignalTypeName(): Logic error: unexpected signal type "
+      << static_cast<int>(sigType) << "\n";
+  } // GeometryCore::SignalTypeName()
+  
+  
+  //......................................................................
   View_t GeometryCore::View(raw::ChannelID_t const channel) const {
     return (channel == raw::InvalidChannelID)
       ? geo::kUnknown: View(ChannelToROP(channel));

--- a/larcorealg/Geometry/GeometryCore.h
+++ b/larcorealg/Geometry/GeometryCore.h
@@ -5326,6 +5326,9 @@ namespace geo {
     geo::SigType_t SignalType(readout::ROPID const& ropid) const;
 
 
+    /// Returns the name of the specified signal type.
+    static std::string SignalTypeName(geo::SigType_t sigType);
+    
     /// @} Readout plane information
 
 
@@ -5709,6 +5712,10 @@ void geo::GeometryCore::Print
         out << "\n" << indent << "    ";
         plane.PrintPlaneInfo
           (std::forward<Stream>(out), indent + "      ", plane.MaxVerbosity);
+        geo::SigType_t const sigType = SignalType(plane.ID());
+        out << "\n" << indent << "      "
+          << "signal type: " << SignalTypeName(sigType)
+          << " (" << static_cast<int>(sigType) << ")";
 
         for(unsigned int w = 0;  w < nWires; ++w) {
           const geo::WireGeo& wire = plane.Wire(w);

--- a/larcorealg/Geometry/GeometryCore.h
+++ b/larcorealg/Geometry/GeometryCore.h
@@ -5326,9 +5326,6 @@ namespace geo {
     geo::SigType_t SignalType(readout::ROPID const& ropid) const;
 
 
-    /// Returns the name of the specified signal type.
-    static std::string SignalTypeName(geo::SigType_t sigType);
-    
     /// @} Readout plane information
 
 


### PR DESCRIPTION
Just one line added for each plane to `geo::GeometryCore::Print()` dump, to express the signal type of the plane.

Merge is low priority, feel free to wait to merge until other pull requests touch this repository.