### PR TITLE
Geometry can tell the TPC closest to an optical detector.

### DIFF
--- a/larcorealg/Geometry/CryostatGeo.cxx
+++ b/larcorealg/Geometry/CryostatGeo.cxx
@@ -116,6 +116,17 @@ namespace geo{
 
 
   //......................................................................
+  OpDetGeo const& CryostatGeo::OpDet(geo::OpDetID const& opdetid) const {
+    if (!opdetid.isValid) {
+      throw cet::exception("CryostatGeo")
+        << "CryostatGeo::OpDet(): invalid optical detector ID.\n";
+    }
+    assert(opdetid.asCryostatID() == ID());
+    return OpDet(opdetid.OpDet);
+  } // CryostatGeo::OpDet(geo::OpDetID)
+
+
+  //......................................................................
   auto CryostatGeo::IterateElements() const -> ElementIteratorBox
     { return fTPCs; }
 

--- a/larcorealg/Geometry/CryostatGeo.cxx
+++ b/larcorealg/Geometry/CryostatGeo.cxx
@@ -25,6 +25,7 @@
 #include <limits> // std::numeric_limits<>
 #include <vector>
 #include <utility> // std::move()
+#include <cassert>
 
 
 namespace geo{
@@ -265,6 +266,32 @@ namespace geo{
   unsigned int CryostatGeo::GetClosestOpDet(double const* point) const
     { return GetClosestOpDet(geo::vect::makePointFromCoords(point)); }
 
+  //......................................................................
+  geo::TPCGeo const& CryostatGeo::GetClosestTPC(geo::Point_t const& point) const
+  {
+    
+    double min_distance2 = std::numeric_limits<double>::max();
+    geo::TPCGeo const* closestTPC = nullptr;
+    for (geo::TPCGeo const& TPC: IterateTPCs()) {
+      double const distance2 = (TPC.GetCenter<geo::Point_t>() - point).Mag2();
+      if (distance2 >= min_distance2) continue;
+      min_distance2 = distance2;
+      closestTPC = &TPC;
+    } // for
+    assert(closestTPC);
+    return *closestTPC;
+    
+  } // CryostatGeo::GetClosestTPC()
+  
+  
+  //......................................................................
+  geo::TPCGeo const& CryostatGeo::GetTPCclosestToOpDet
+    (geo::OpDetID const& opdetid) const
+  {
+    return GetClosestTPC(OpDet(opdetid).GetCenter());
+  } // CryostatGeo::GetTPCclosestToOpDet()
+  
+  
   //......................................................................
   void CryostatGeo::InitCryoBoundaries() {
 

--- a/larcorealg/Geometry/CryostatGeo.h
+++ b/larcorealg/Geometry/CryostatGeo.h
@@ -363,6 +363,32 @@ namespace geo {
     /// Return the iopdet'th optical detector in the cryostat
     const OpDetGeo&   OpDet(unsigned int iopdet)                const;
 
+    /**
+     * @brief Return the optical detector with the specified ID.
+     * @param opdetid ID of the requested optical detector
+     * @return the optical detector with the requested `opdetid`
+     * @throw cet::exception (category: "CryostatGeo") if the ID is invalid or
+     *        points to a optical detector that does not exist in this cryostat
+     * 
+     * If `opdetid` points to a different cryostat, behaviour is unspecified.
+     */
+    OpDetGeo const& OpDet(geo::OpDetID const& opdetid) const;
+
+    /**
+     * @brief Returns an object suitable for iterating through all optical
+     *        detectors.
+     * @see `IterateTPCs()`
+     *
+     * The returned value can be used in a range-for loop like:
+     * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+     * for (geo::OpDetGeo const& opDet: cryo.IterateOpDets()) { ... }
+     * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+     * The resulting sequence exposes the optical detectors within the cryostat
+     * in their ID order, from `OpDet` `0` to `NOpDet() - 1`.
+     */
+    auto const& IterateOpDets() const { return fOpDets; }
+    
+    
     /// Returns the index of the optical detector in this cryostat closest to
     /// `point`.
     unsigned int GetClosestOpDet(geo::Point_t const& point) const;

--- a/larcorealg/Geometry/CryostatGeo.h
+++ b/larcorealg/Geometry/CryostatGeo.h
@@ -343,6 +343,21 @@ namespace geo {
     geo::TPCGeo const* PositionToTPCptr
       (geo::Point_t const& point, double wiggle) const;
 
+    /**
+     * @brief Returns the TPC whose center is the closest to `point`.
+     * @param point the location to test
+     * @return the TPC whose center is the closest to `point`
+     * @see `PositionToTPC()`
+     * 
+     * The TPC with center closest to `point` is returned.
+     * Differently from `PositionToTPC()`, the `point` is not required to be
+     * _inside_ any TPC, and a valid TPC is always returned.
+     * 
+     * If the specified `point` is exactly in the middle between TPC, one
+     * of them is returned, and it is not defined which one.
+     */
+    geo::TPCGeo const& GetClosestTPC(geo::Point_t const& point) const;
+    
     /// Returns the largest number of planes among the TPCs in this cryostat
     unsigned int MaxPlanes() const;
 
@@ -401,6 +416,10 @@ namespace geo {
 
     /// Get name of opdet geometry element
     std::string  OpDetGeoName()                                 const { return fOpDetGeoName; }
+
+    /// Returns the TPC closest (center-to-center) to `opDet` in this cryostat.
+    geo::TPCGeo const& GetTPCclosestToOpDet(geo::OpDetID const& opDet) const;
+    
 
     /// @}
     // END Optical detector access ---------------------------------------------

--- a/larcorealg/Geometry/GeometryCore.cxx
+++ b/larcorealg/Geometry/GeometryCore.cxx
@@ -1906,6 +1906,20 @@ namespace geo {
 
 
   //--------------------------------------------------------------------
+  geo::TPCGeo const& GeometryCore::GetTPCclosestToOpDet
+    (geo::OpDetID const& oid) const
+  {
+    if (!oid.isValid) {
+      throw cet::exception("GeometryCore")
+        << "geo::GeometryCore::GetTPCclosestToOpDet(): "
+        "invalid optical detector specified.\n";
+    }
+    
+    return Cryostat(oid).GetTPCclosestToOpDet(oid);
+    
+  } // GeometryCore::GetTPCclosestToOpDet()
+  
+  //--------------------------------------------------------------------
   bool GeometryCore::WireIDIntersectionCheck
     (const geo::WireID& wid1, const geo::WireID& wid2) const
   {

--- a/larcorealg/Geometry/GeometryCore.cxx
+++ b/larcorealg/Geometry/GeometryCore.cxx
@@ -1789,13 +1789,6 @@ namespace geo {
 
   //============================================================================
   //--------------------------------------------------------------------
-  // Return gdml string which gives sensitive opdet name
-  std::string GeometryCore::OpDetGeoName(unsigned int c) const
-  {
-    return Cryostat(c).OpDetGeoName();
-  }
-
-  //--------------------------------------------------------------------
   // Convert OpDet, Cryo into unique OpDet number
   unsigned int GeometryCore::OpDetFromCryo(unsigned int o, unsigned int c ) const
   {
@@ -1832,6 +1825,27 @@ namespace geo {
     return INT_MAX;
   }
 
+  
+  //--------------------------------------------------------------------
+  // Return gdml string which gives sensitive opdet name
+  std::string GeometryCore::OpDetGeoName(unsigned int c) const
+  {
+    return Cryostat(c).OpDetGeoName();
+  }
+
+  //--------------------------------------------------------------------
+  geo::OpDetGeo const& GeometryCore::OpDet(geo::OpDetID const& oid) const {
+    
+    if (!oid.isValid) {
+      throw cet::exception("GeometryCore")
+        << "geo::GeometryCore::OpDet(): invalid optical detector specified.\n";
+    }
+    
+    return Cryostat(oid).OpDet(oid);
+    
+  } // GeometryCore::OpDet()
+  
+  
   //--------------------------------------------------------------------
   const OpDetGeo& GeometryCore::OpDetGeoFromOpChannel(unsigned int OpChannel) const
   {

--- a/larcorealg/Geometry/GeometryCore.h
+++ b/larcorealg/Geometry/GeometryCore.h
@@ -4512,6 +4512,23 @@ namespace geo {
     unsigned int GetClosestOpDet(geo::Point_t const& point) const;
     unsigned int GetClosestOpDet(double const* point) const;
     //@}
+    
+    
+    //@{
+    /**
+     * @brief Returns the optical detector in the cryostat closest to `point`.
+     * @param oid ID of the optical detector
+     * @return the TPC closest to the optical detector `oid`
+     * @see `geo::CryostatGeo::GetTPCclosestToOpDet()`
+     * @throw cet::exception (category `"GeometryCore"`) if `oid` invalid
+     * 
+     * The TPC closest to the center of the specified optical detector is
+     * returned.
+     * 
+     * See `geo::CryostatGeo::GetTPCclosestToOpDet()` for details.
+     */
+    geo::TPCGeo const& GetTPCclosestToOpDet(geo::OpDetID const& oid) const;
+    //@}
 
 
     //
@@ -5749,10 +5766,13 @@ void geo::GeometryCore::Print
       } // for plane
     } // for TPC
 
-    unsigned int nOpDets = cryostat.NOpDet();
+    unsigned int const nOpDets = cryostat.NOpDet();
     for (unsigned int iOpDet = 0; iOpDet < nOpDets; ++iOpDet) {
       geo::OpDetGeo const& opDet = cryostat.OpDet(iOpDet);
-      out << "\n" << indent << "  [OpDet #" << iOpDet << "] ";
+      out << "\n" << indent << "  [OpDet #" << iOpDet << "] "
+        << "(closest: " << cryostat.GetTPCclosestToOpDet(opDet.ID()).ID()
+        << ") ";
+      
       opDet.PrintOpDetInfo
         (std::forward<Stream>(out), indent + "  ", opDet.MaxVerbosity);
     } // for

--- a/larcorealg/Geometry/GeometryCore.h
+++ b/larcorealg/Geometry/GeometryCore.h
@@ -4455,26 +4455,33 @@ namespace geo {
     // group features
     //
 
+    //@{
     /// Number of OpDets in the whole detector
     unsigned int NOpDets() const;
+    //@}
 
 
     //
     // access
     //
+    
+    //@{
     /**
      * @brief Returns the `geo::OpDetGeo` object for the given channel number.
      * @param OpChannel optical detector unique channel number
      * @see GeometryCoreOpDetGeometry "optical detector identification"
      */
     OpDetGeo const& OpDetGeoFromOpChannel(unsigned int OpChannel) const;
+    //@}
 
+    //@{
     /**
      * @brief Returns the `geo::OpDetGeo` object for the given detector number.
      * @param OpDet optical detector unique number
      * @see GeometryCoreOpDetGeometry "optical detector identification"
      */
     OpDetGeo const& OpDetGeoFromOpDet(unsigned int OpDet) const;
+    //@}
 
 
     //@{
@@ -4498,6 +4505,7 @@ namespace geo {
     // object description
     //
 
+    //@{
     /**
      * @brief Returns gdml string which gives sensitive opdet name
      * @param c ID of the cryostat the detector is in
@@ -4507,6 +4515,7 @@ namespace geo {
      * @todo Change to use CryostatID
      */
     std::string OpDetGeoName(unsigned int c = 0) const;
+    //@}
 
     /// @} Optical detector access and information
 

--- a/larcorealg/Geometry/GeometryCore.h
+++ b/larcorealg/Geometry/GeometryCore.h
@@ -4467,6 +4467,19 @@ namespace geo {
     
     //@{
     /**
+     * @brief Returns the optical detector with the specified ID.
+     * @param oid ID of the optical detector
+     * @return the optical detector `oid`
+     * @throw cet::exception (category `"GeometryCore"`) if `oid` ID is invalid
+     * @throw cet::exception (category `"GeometryCore"`) if `oid` does not
+     *        represent any optical detector
+     */
+    geo::OpDetGeo const& OpDet(geo::OpDetID const& oid) const;
+    //@}
+    
+    
+    //@{
+    /**
      * @brief Returns the `geo::OpDetGeo` object for the given channel number.
      * @param OpChannel optical detector unique channel number
      * @see GeometryCoreOpDetGeometry "optical detector identification"

--- a/test/Geometry/GeometryTestAlg.cxx
+++ b/test/Geometry/GeometryTestAlg.cxx
@@ -565,19 +565,29 @@ namespace geo{
 
 
   void GeometryTestAlg::printAllGeometry() const {
-    const unsigned int nCryostats = geom->Ncryostats();
     mf::LogVerbatim("GeometryTest") << "Detector " << geom->DetectorName()
-      << " has " << nCryostats << " cryostats:";
-    for(unsigned int c = 0; c < nCryostats; ++c) {
-      const geo::CryostatGeo& cryostat = geom->Cryostat(c);
+      << " has " << geom->Ncryostats() << " cryostats:";
+    for (geo::CryostatGeo const& cryostat: geom->IterateCryostats()) {
       const unsigned int nTPCs = cryostat.NTPC();
-      mf::LogVerbatim("GeometryTest") << "  cryostat #" << c << " at "
-        << lar::dump::vector3D(cryostat.GetCenter()) << " cm has "
-        << nTPCs << " TPC(s):";
-      for(unsigned int t = 0;  t < nTPCs; ++t) {
-        const geo::TPCGeo& tpc = cryostat.TPC(t);
+      mf::LogVerbatim("GeometryTest") << "  cryostat " << cryostat.ID()
+        << " at " << cryostat.GetCenter() << " cm has " << nTPCs << " TPC(s):";
+      for(geo::TPCGeo const& tpc: cryostat.IterateTPCs()) {
         printWiresInTPC(tpc, "    ");
       } // for TPC
+      
+      unsigned int const nOpDets = cryostat.NOpDet();
+      if (nOpDets > 0U) {
+        mf::LogVerbatim log { "GeometryTest" };
+        log << "  cryostat " << cryostat.ID()
+          << " has " << nOpDets << " optical detectors:";
+        for(geo::OpDetGeo const& opDet: cryostat.IterateOpDets())
+          opDet.PrintOpDetInfo(log << "\n    ", "", 1U);
+      }
+      else {
+        mf::LogVerbatim("GeometryTest") << "  cryostat " << cryostat.ID()
+          << " has no optical detector.";
+      }
+      
     } // for cryostat
     printAuxiliaryDetectors();
     mf::LogVerbatim("GeometryTest") << "End of detector "

--- a/test/Geometry/GeometryTestAlg.h
+++ b/test/Geometry/GeometryTestAlg.h
@@ -33,6 +33,7 @@ namespace geo {
 
   // forward declarations
   class GeometryCore;
+  class CryostatGeo;
   class TPCGeo;
   class PlaneGeo;
   class AuxDetGeo;
@@ -143,6 +144,7 @@ namespace geo {
     void printAllGeometry() const;
     void testFindVolumes();
     void testCryostat();
+    void testOpticalDetectors() const;
     void testTPC(geo::CryostatID const& cid);
     void testPlaneDirections() const;
     void testWireOrientations() const;
@@ -221,6 +223,9 @@ namespace geo {
       (double const pos[3], unsigned int expectedDet, unsigned int expectedSens)
       const;
 
+    /// Performs the tests on all optical detectors in a cryostat.
+    void testCryoOpticalDetectors(geo::CryostatGeo const& cryo) const;
+    
     /// Performs the wire intersection test at a single point
     unsigned int testWireIntersectionAt
       (geo::TPCGeo const& TPC, TVector3 const& point) const;


### PR DESCRIPTION
I have added a feature that I have been asked about a few times (the last one by Iker de Icaza), to find the TPC closest to an optical detector.
The main method is `geo::GeometryCore::GetTPCclosestToOpDet()` (an equivalent one is also provided in `geo::CryostatGeo`).

The algorithm implemented here is quite simple: look for the TPC whose centre is closest to the PMT centre.
The most obvious failure for this algorithm is when there are multiple TPC at a similar distance. This may happen in pathological cases where an optical detector is set in the border between two logical TPC (as it may have happened in ICARUS, where each physical TPC is split in two halves; but PMT are behind just one of them), or more relevantly, in optical detectors located in a shared cathode (future DUNE?) or anode (also: future DUNE?). In these cases, the question is effectively which is the right answer.
Alternative implementations are to return _all_ the TPC which are at the same closest distance (requires a different interface than the one proposed here), or to return the one TPC that the normal to the optical detector points to (which may or may not be useful for DUNE depending on whether the same optical detector is facing only one, or both of the drift volumes it is in between).
I summon @aihimmel for comments on this point.

The pull request also includes minor interface extensions that are used in the feature and that mirror the ones already existing for `geo::TPCGeo`.

This feature is non-breaking.