### PR TITLE
Intersection of two wires and related utilities

### DIFF
--- a/larcorealg/Geometry/GeometryCore.cxx
+++ b/larcorealg/Geometry/GeometryCore.cxx
@@ -1356,15 +1356,6 @@ namespace geo {
 
 
   //......................................................................
-  geo::Point_t GeometryCore::WiresIntersect
-    (geo::WireGeo const& wire1, geo::WireGeo const& wire2) const
-  {
-    assert(!wire2.isParallelTo(wire1));
-    return geo::WiresIntersection(wire1, wire2);
-  } // GeometryCore::WiresIntersect()
-
-
-  //......................................................................
   bool GeometryCore::WireIDsIntersect(
     const geo::WireID& wid1, const geo::WireID& wid2,
     geo::WireIDIntersection & widIntersect

--- a/larcorealg/Geometry/GeometryCore.cxx
+++ b/larcorealg/Geometry/GeometryCore.cxx
@@ -1444,12 +1444,14 @@ namespace geo {
     geo::WireGeo const& wire2 = Wire(wid2);
 
     // distance of the intersection point from the center of the two wires:
-    double ofs1, ofs2;
-    std::tie(intersection, ofs1, ofs2)
+    geo::IntersectionPointAndOffsets<geo::Point_t> intersectionAndOffset
       = geo::WiresIntersectionAndOffsets(wire1, wire2);
+    intersection = intersectionAndOffset.point;
     
-    bool const within
-      = (std::abs(ofs1) <= wire1.HalfL()) && (std::abs(ofs2) <= wire2.HalfL());
+    bool const within = (
+      (std::abs(intersectionAndOffset.offset1) <= wire1.HalfL())
+      && (std::abs(intersectionAndOffset.offset2) <= wire2.HalfL())
+      );
 
     // return whether the intersection is within the length of both wires
     return within;

--- a/larcorealg/Geometry/GeometryCore.cxx
+++ b/larcorealg/Geometry/GeometryCore.cxx
@@ -41,6 +41,7 @@
 #include <cmath> // std::abs() ...
 #include <sstream> // std::ostringstream
 #include <vector>
+#include <tuple>
 #include <algorithm> // std::for_each(), std::transform()
 #include <iterator> // std::back_inserter()
 #include <utility> // std::swap()
@@ -1442,13 +1443,13 @@ namespace geo {
     geo::WireGeo const& wire1 = Wire(wid1);
     geo::WireGeo const& wire2 = Wire(wid2);
 
-    std::pair<double, double> locOnWires;
-    intersection = geo::WiresIntersection(wire1, wire2, &locOnWires);
     // distance of the intersection point from the center of the two wires:
-    auto const [ t, u ] = locOnWires;
-
+    double ofs1, ofs2;
+    std::tie(intersection, ofs1, ofs2)
+      = geo::WiresIntersectionAndOffsets(wire1, wire2);
+    
     bool const within
-      = (std::abs(t) <= wire1.HalfL()) && (std::abs(u) <= wire2.HalfL());
+      = (std::abs(ofs1) <= wire1.HalfL()) && (std::abs(ofs2) <= wire2.HalfL());
 
     // return whether the intersection is within the length of both wires
     return within;

--- a/larcorealg/Geometry/GeometryCore.cxx
+++ b/larcorealg/Geometry/GeometryCore.cxx
@@ -1353,6 +1353,16 @@ namespace geo {
 
   } // GeometryCore::IntersectSegments()
 
+
+  //......................................................................
+  geo::Point_t GeometryCore::WiresIntersect
+    (geo::WireGeo const& wire1, geo::WireGeo const& wire2) const
+  {
+    assert(!wire2.isParallelTo(wire1));
+    return WiresIntersectImpl(wire1, wire2);
+  } // GeometryCore::WiresIntersect()
+
+
   //......................................................................
   bool GeometryCore::WireIDsIntersect(
     const geo::WireID& wid1, const geo::WireID& wid2,
@@ -1429,44 +1439,13 @@ namespace geo {
       return false;
     }
 
-    /*
-     * the point on the first wire:
-     *
-     *     p1(t) = c1 + t w1 (c1 the center of the wire, w1 its direction[1])
-     *
-     * has the minimal distance from the other wire (c2 + u w2, with the same
-     * notation) at
-     *
-     *     t = [(dc,w1) - (dc,w2)(w1,w2)] / [ 1 - (w1,w2)^2 ]
-     *     u = [-(dc,w2) + (dc,w1)(w1,w2)] / [ 1 - (w1,w2)^2 ]
-     *
-     * (where (a,b) is a scalar product and dc = (c2 - c1) ).
-     * If w1 and w2 are unit vectors, t and u are in fact the distance of the
-     * point from the center of the respective wires in "standard" geometry
-     * units.
-     *
-     */
-
     geo::WireGeo const& wire1 = Wire(wid1);
-    decltype(auto) c1 = wire1.GetCenter();
-    decltype(auto) w1 = wire1.Direction();
-
     geo::WireGeo const& wire2 = Wire(wid2);
-    decltype(auto) c2 = wire2.GetCenter();
-    decltype(auto) w2 = wire2.Direction();
 
-    auto const dc = c2 - c1;
-
-    // note: we are not checking that w1 and w2 are not parallel.
-    using geo::vect::dot;
-    double const w1w2 = dot(w1, w2); // this is cos(angle), angle between wires
-    double const cscAngle2 = 1.0 / (1.0 - cet::square(w1w2)); // this is 1/sin^2(angle)
-    double const dcw1 = dot(dc, w1);
-    double const dcw2 = dot(dc, w2);
-    double const t = (dcw1 - (dcw2 * w1w2)) * cscAngle2;
-    double const u = (-dcw2 + (dcw1 * w1w2)) * cscAngle2;
-
-    intersection = c1 + t * w1;
+    std::pair<double, double> locOnWires;
+    intersection = WiresIntersectImpl(wire1, wire2, &locOnWires);
+    // distance of the intersection point from the center of the two wires:
+    auto const [ t, u ] = locOnWires;
 
     bool const within
       = (std::abs(t) <= wire1.HalfL()) && (std::abs(u) <= wire2.HalfL());
@@ -1889,6 +1868,55 @@ namespace geo {
   // Find the closest OpChannel to this point, in the appropriate cryostat
   unsigned int GeometryCore::GetClosestOpDet(double const* point) const
     { return GetClosestOpDet(geo::vect::makePointFromCoords(point)); }
+
+
+  //--------------------------------------------------------------------
+  geo::Point_t GeometryCore::WiresIntersectImpl(
+    geo::WireGeo const& wire1, geo::WireGeo const& wire2,
+    std::pair<double, double>* locOnWires /* = nullptr */
+  ) const {
+    /*
+     * The point on the first wire:
+     *
+     *     p1(t) = c1 + t w1 (c1 the center of the wire, w1 its direction[1])
+     *
+     * has the minimal distance from the other wire (c2 + u w2, with the same
+     * notation) at
+     *
+     *     t = [(dc,w1) - (dc,w2)(w1,w2)] / [ 1 - (w1,w2)^2 ]
+     *     u = [-(dc,w2) + (dc,w1)(w1,w2)] / [ 1 - (w1,w2)^2 ]
+     *
+     * (where (a,b) is a scalar product and dc = (c2 - c1) ).
+     * If w1 and w2 are unit vectors, t and u are in fact the distance of the
+     * point from the center of the respective wires in "standard" geometry
+     * units.
+     * 
+     * If `locOnWires` is non-null, it is filled with { t, u }.
+     */
+
+    geo::Point_t const& c1 = wire1.GetCenter<geo::Point_t>();
+    geo::Vector_t const& w1 = wire1.Direction<geo::Vector_t>();
+
+    geo::Point_t const& c2 = wire2.GetCenter<geo::Point_t>();
+    geo::Vector_t const& w2 = wire2.Direction<geo::Vector_t>();
+
+    geo::Vector_t const dc = c2 - c1;
+
+    // note: we are not checking that w1 and w2 are not parallel.
+    using geo::vect::dot;
+    double const w1w2 = dot(w1, w2); // this is cos(angle), angle between wires
+    double const cscAngle2 = 1.0 / (1.0 - cet::square(w1w2)); // this is 1/sin^2(angle)
+    double const dcw1 = dot(dc, w1);
+    double const dcw2 = dot(dc, w2);
+    
+    double const t = (dcw1 - (dcw2 * w1w2)) * cscAngle2;
+    if (locOnWires) {
+      double const u = (-dcw2 + (dcw1 * w1w2)) * cscAngle2;
+      *locOnWires = { t, u };
+    }
+    
+    return c1 + t * w1;
+  } // GeometryCore::WiresIntersectImpl()
 
 
   //--------------------------------------------------------------------

--- a/larcorealg/Geometry/GeometryCore.h
+++ b/larcorealg/Geometry/GeometryCore.h
@@ -5527,13 +5527,6 @@ namespace geo {
     /// @param builder the algorithm to be used
     void BuildGeometry(geo::GeometryBuilder& builder);
 
-    /// Geometry implementation of wire intersection,
-    /// also fills intersection location (from center) on the wires.
-    geo::Point_t WiresIntersectImpl(
-      geo::WireGeo const& wire1, geo::WireGeo const& wire2,
-      std::pair<double, double>* locOnWires = nullptr
-      ) const;
-    
     /// Wire ID check for WireIDsIntersect methods
     bool WireIDIntersectionCheck
       (const geo::WireID& wid1, const geo::WireID& wid2) const;

--- a/larcorealg/Geometry/GeometryCore.h
+++ b/larcorealg/Geometry/GeometryCore.h
@@ -4151,6 +4151,7 @@ namespace geo {
      * @param wid2 ID of the other wire
      * @param[out] intersection the intersection point (global coordinates)
      * @return whether an intersection was found inside the TPC the wires belong
+     * @see `geo::WiresIntersection()`, `geo::LineClosestPoint()`
      *
      * The "intersection" refers to the projection of the wires into the same
      * wire plane. The coordinate along the drift direction is arbitrarily set
@@ -4164,6 +4165,11 @@ namespace geo {
      * To test that the result is not infinity (nor NaN), use
      * `geo::vect::isfinite(intersection)` etc.
      *
+     * @note If `geo::WireGeo` objects are already available, using instead
+     *       the free function `geo::WiresIntersection()` or the method
+     *       `geo::WireGeo::IntersectionWith()` is faster (and _recommended_).
+     *       For purely geometric intersection, `geo::LineClosestPoint()` is
+     *       also available.
      */
     bool WireIDsIntersect(
       WireID const& wid1, WireID const& wid2,
@@ -4171,23 +4177,6 @@ namespace geo {
       ) const;
     bool WireIDsIntersect
       (WireID const& wid1, WireID const& wid2, TVector3& intersection) const;
-    //@}
-
-    //@{
-    /**
-     * @brief Computes the intersection between two wires.
-     * @param wire1 the first wire
-     * @param wire2 the other wire
-     * @return the intersection point (global coordinates)
-     *
-     * The "intersection" point lies on `wire1` and it is defined as the point
-     * on that wire closest to `wire2`.
-     * The two wires are assumed not to be parallel, and when this prerequisite
-     * is not met the behaviour is undefined. The caller can check that
-     * condition by requiring e.g. `!wire1.isParallelTo(wire2)`.
-     */
-    geo::Point_t WiresIntersect
-      (geo::WireGeo const& wire1, geo::WireGeo const& wire2) const;
     //@}
 
     //@{

--- a/larcorealg/Geometry/GeometryCore.h
+++ b/larcorealg/Geometry/GeometryCore.h
@@ -4149,7 +4149,7 @@ namespace geo {
      * @brief Computes the intersection between two wires.
      * @param wid1 ID of the first wire
      * @param wid2 ID of the other wire
-     * @param intersection (output) the intersection point (global coordinates)
+     * @param[out] intersection the intersection point (global coordinates)
      * @return whether an intersection was found inside the TPC the wires belong
      *
      * The "intersection" refers to the projection of the wires into the same
@@ -4173,6 +4173,24 @@ namespace geo {
       (WireID const& wid1, WireID const& wid2, TVector3& intersection) const;
     //@}
 
+    //@{
+    /**
+     * @brief Computes the intersection between two wires.
+     * @param wire1 the first wire
+     * @param wire2 the other wire
+     * @return the intersection point (global coordinates)
+     *
+     * The "intersection" point lies on `wire1` and it is defined as the point
+     * on that wire closest to `wire2`.
+     * The two wires are assumed not to be parallel, and when this prerequisite
+     * is not met the behaviour is undefined. The caller can check that
+     * condition by requiring e.g. `!wire1.isParallelTo(wire2)`.
+     */
+    geo::Point_t WiresIntersect
+      (geo::WireGeo const& wire1, geo::WireGeo const& wire2) const;
+    //@}
+
+    //@{
     /**
      * @brief Computes the intersection between two wires.
      * @param wid1 ID of the first wire
@@ -4198,6 +4216,7 @@ namespace geo {
     bool WireIDsIntersect
       (WireID const& wid1, WireID const& wid2, WireIDIntersection& widIntersect)
       const;
+    //@}
 
     /**
      * @brief Returns the intersection point of two wires
@@ -5508,6 +5527,13 @@ namespace geo {
     /// @param builder the algorithm to be used
     void BuildGeometry(geo::GeometryBuilder& builder);
 
+    /// Geometry implementation of wire intersection,
+    /// also fills intersection location (from center) on the wires.
+    geo::Point_t WiresIntersectImpl(
+      geo::WireGeo const& wire1, geo::WireGeo const& wire2,
+      std::pair<double, double>* locOnWires = nullptr
+      ) const;
+    
     /// Wire ID check for WireIDsIntersect methods
     bool WireIDIntersectionCheck
       (const geo::WireID& wid1, const geo::WireID& wid2) const;

--- a/larcorealg/Geometry/LineClosestPoint.h
+++ b/larcorealg/Geometry/LineClosestPoint.h
@@ -32,6 +32,10 @@ namespace geo {
     double offset1; ///< Distance from reference point of first line.
     double offset2; ///< Distance from reference point of second line.
     
+    /// Helper to assign to `std::tie()`.
+    operator std::tuple<Point&, double&, double&>() noexcept
+      { return { point, offset1, offset2 }; }
+    
   }; // IntersectionPointAndOffsets<>
   
   

--- a/larcorealg/Geometry/LineClosestPoint.h
+++ b/larcorealg/Geometry/LineClosestPoint.h
@@ -1,0 +1,138 @@
+/**
+ * @file   larcorealg/Geometry/LineClosestPoint.h
+ * @brief  Utility for intersection of two 3D lines.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @see    larcorealg/Geometry/LineClosestPoint.tcc,
+ *         larcorealg/Geometry/WireGeo.h
+ *
+ * This utility is used as implementation of detector wires, but it can stand on
+ * its own.
+ * 
+ * This library is header-only and (likely) no additional linkage.
+ */
+
+
+#ifndef LARCOREALG_GEOMETRY_LINECLOSESTPOINT_H
+#define LARCOREALG_GEOMETRY_LINECLOSESTPOINT_H
+
+
+// C++ standard library
+#include <utility> // std::pair<>
+
+
+// -----------------------------------------------------------------------------
+namespace geo {
+
+  /**
+   * @brief Returns the point of a line that is closest to a second line.
+   * @tparam Point a type describing a point
+   * @tparam Vector a type describing a direction (displacement vector)
+   * @param refA a reference point on the first line
+   * @param dirA the direction of the first line
+   * @param refB a reference point on the second line
+   * @param dirB the direction of the second line
+   * @param[out] locOnLines pointer to additional output (see description)
+   * @return the point of `A` closest to `B`
+   *
+   * The point of line `A` that is closest to line `B` is returned.
+   * 
+   * The two lines are _assumed_ not to be parallel, and when this prerequisite
+   * is not met the behaviour is undefined.
+   * 
+   * @note This formulation is valid for lines in a Euclidean space of any
+   *       dimension; the minimized distance is the Euclidean one.
+   * 
+   * If `locOnLines` is specified, a pair is returned with the distance of the
+   * closest point from the reference points on line A (`first`) and B
+   * (`second`), in units of `dirA` and `dirB` respectively.
+   * 
+   * 
+   * Requirements
+   * -------------
+   * 
+   * The following operations between points, vectors and scalars must be
+   * defined:
+   * 
+   * * `Vector operator- (Point, Point)`: the difference of two points always
+   *   exists and it returns a `Vector`;
+   * * `Point operator+ (Point, Vector)`: translation of a point by a
+   *   displacement vector;
+   * * `Vector operator* (Vector, double)`: vector scaling by a real factor;
+   * * `double dot(Vector, Vector)`: scalar (inner) product of two vectors.
+   * 
+   */
+  template <typename Point, typename Vector>
+  Point LineClosestPoint(
+    Point const& startA, Vector const& dirA,
+    Point const& startB, Vector const& dirB,
+    std::pair<double, double>* locOnLines = nullptr
+    );
+
+  
+  /**
+   * @brief Returns the point of a line that is closest to a second line.
+   * @tparam Point a type describing a point
+   * @tparam UnitVector a type describing a direction (unit vector)
+   * @param refA a reference point on the first line
+   * @param dirA the direction of the first line (unity-normed)
+   * @param refB a reference point on the second line
+   * @param dirB the direction of the second line (unity-normed)
+   * @param[out] locOnLines pointer to additional output (see description)
+   * @return the point of `A` closest to `B`
+   *
+   * The point of line `A` that is closest to line `B` is returned.
+   * 
+   * The two lines are _assumed_ not to be parallel, and when this prerequisite
+   * is not met the behaviour is undefined.
+   * 
+   * The two directions are _required_ to have norm `1`. While formally if this
+   * prerequisite is not met the result is undefined, the result will be still
+   * mostly correct if their norm departs from unity only by a rounding error.
+   * The more the vectors deviate from that condition, the larger the error
+   * in the result.
+   *
+   * @note This formulation is valid for lines in a Euclidean space of any
+   *       dimension; the minimized distance is the Euclidean one.
+   * 
+   * If `locOnLines` is specified, a pair is returned with the distance of the
+   * closest point from the reference points on line A (`first`) and B
+   * (`second`), in the same space units as the points and vectors.
+   * 
+   * 
+   * Requirements
+   * -------------
+   * 
+   * The following operations between points, vectors and scalars must be
+   * defined:
+   * 
+   * * `Vector operator* (UnitVector, double)`: scaling of a unit vector by a
+   *   real factor to produce a non-unit vector;
+   * * `Vector operator- (Point, Point)`: the difference of two points always
+   *   exists and it returns a `Vector`;
+   * * `Point operator+ (Point, Vector)`: translation of a point by a
+   *   displacement vector;
+   * * `double dot(Vector, UnitVector)`, `double dot(UnitVector, UnitVector)`:
+   *   scalar (inner) product of one unit vector and a vector, or two unit
+   *   vectors.
+   * 
+   */
+  template <typename Point, typename UnitVector>
+  Point LineClosestPointWithUnitVectors(
+    Point const& startA, UnitVector const& dirA,
+    Point const& startB, UnitVector const& dirB,
+    std::pair<double, double>* locOnLines = nullptr
+    );
+  
+  
+} // namespace geo
+
+
+// -----------------------------------------------------------------------------
+// ---  template implementation
+// -----------------------------------------------------------------------------
+#include "larcorealg/Geometry/LineClosestPoint.tcc"
+
+// -----------------------------------------------------------------------------
+
+
+#endif // LARCOREALG_GEOMETRY_LINECLOSESTPOINT_H

--- a/larcorealg/Geometry/LineClosestPoint.h
+++ b/larcorealg/Geometry/LineClosestPoint.h
@@ -22,6 +22,19 @@
 
 // -----------------------------------------------------------------------------
 namespace geo {
+  
+  
+  /// Data structure for return values of `LineClosestPointAndOffsets()`.
+  template <typename Point>
+  struct IntersectionPointAndOffsets {
+    
+    Point point;    ///< Intersection point.
+    double offset1; ///< Distance from reference point of first line.
+    double offset2; ///< Distance from reference point of second line.
+    
+  }; // IntersectionPointAndOffsets<>
+  
+  
 
   /**
    * @brief Returns the point of a line that is closest to a second line.
@@ -31,9 +44,10 @@ namespace geo {
    * @param dirA the direction of the first line
    * @param refB a reference point on the second line
    * @param dirB the direction of the second line
-   * @return a triplet: `<0>`: the point of `A` closest to `B`,
-   *         `<1>`: its offset on `A` in units of `dirA`,
-   *         `<2>`: its offset on `B` in units of `dirB`
+   * @return a data structure with three fields:
+   *         `point`: the point of `A` closest to `B`,
+   *         `offset1`: its offset on `A` in units of `dirA`,
+   *         `offset2`: its offset on `B` in units of `dirB`
    * @see `LineClosestPointWithUnitVectors()`
    * @see `LineClosestPointAndOffsets()`
    *
@@ -44,7 +58,9 @@ namespace geo {
    * reference points of the two lines, in the direction specified by
    * `dirA`/`dirB`.
    * 
-   * The return value is a triplet, which is most easily unpacked immediately:
+   * The return value is a data structure of type
+   * `geo::IntersectionPointAndOffsets`, which is most easily unpacked
+   * immediately:
    * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
    * auto [ point, offsetA, offsetB ] = geo::LineClosestPointAndOffsets(
    *   geo::Point_t{ 2, 0, 1 }, geo::Vector_t{ 0.0,   0.5, 0.0 },
@@ -53,19 +69,23 @@ namespace geo {
    * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    * will set `point` to `geo::Point{ 2, 1, 1 }`, `offsetA` to `2` and `offsetB`
    * to `2.309...`.
-   * To reassign the variables after they have been defined, instead:
+   * To reassign the variables after they have been defined, though, a temporary
+   * structure is needed:
    * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
-   * std::tie(point, offsetA, offsetB) = geo::LineClosestPointAndOffsets(
+   * auto const xsectAndOfs = geo::LineClosestPointAndOffsets(
    *   geo::Point_t{ 0, 1, 0 }, geo::Vector_t{ 0.866, 0.0, 0.0 },
    *   geo::Point_t{ 2, 0, 1 }, geo::Vector_t{ 0.0,   0.5, 0.0 }
    *   );
+   * point = xsectAndOfs.point;
+   * offsetA = xsectAndOfs.offset1;
+   * offsetB = xsectAndOfs.offset2;
    * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    * (`point` to `geo::Point{ 2, 1, 0 }`, `offsetA` to `2.039...` and `offsetB`
    * to `2`, because the intersection point is always on the first line).
    * 
    */
   template <typename Point, typename Vector>
-  std::tuple<Point, double, double> LineClosestPointAndOffsets(
+  IntersectionPointAndOffsets<Point> LineClosestPointAndOffsets(
     Point const& startA, Vector const& dirA,
     Point const& startB, Vector const& dirB
     );
@@ -123,15 +143,18 @@ namespace geo {
    * @param dirA the direction of the first line (unity-normed)
    * @param refB a reference point on the second line
    * @param dirB the direction of the second line (unity-normed)
-   * @return a triplet: `<0>`: the point of `A` closest to `B`,
-   *         `<1>`: its offset on `A` in units of `dirA` (i.e. unity),
-   *         `<2>`: its offset on `B` in units of `dirB` (i.e. unity)
+   * @return a data structure with three fields:
+   *         `point`: the point of `A` closest to `B`,
+   *         `offset1`: its offset on `A` in units of `dirA` (i.e. unity),
+   *         `offset2`: its offset on `B` in units of `dirB` (i.e. unity)
    * @see `LineClosestPointWithUnitVectors()`
    * @see `LineClosestPointAndOffsets()`
    *
    * The point of line `A` that is closest to line `B` is returned.
    * 
-   * The return value is a triplet, which is most easily unpacked immediately:
+   * The return value is a data structure of type
+   * `geo::IntersectionPointAndOffsets`, which is most easily unpacked
+   * immediately:
    * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
    * auto [ point, offsetA, offsetB ] = geo::LineClosestPointAndOffsetsWithUnitVectors(
    *   geo::Point_t{ 2, 0, 1 }, geo::Vector_t{ 0, 1, 0 },
@@ -142,17 +165,20 @@ namespace geo {
    * to `2`.
    * To reassign the variables after they have been defined, instead:
    * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
-   * std::tie(point, offsetA, offsetB) = geo::LineClosestPointAndOffsetsWithUnitVectors(
+   * auto const xsectAndOfs = geo::LineClosestPointAndOffsetsWithUnitVectors(
    *   geo::Point_t{ 0, 1, 0 }, geo::Vector_t{ 1, 0, 0 },
    *   geo::Point_t{ 2, 0, 1 }, geo::Vector_t{ 0, 1, 0 }
    *   );
+   * point = xsectAndOfs.point;
+   * offsetA = xsectAndOfs.offset1;
+   * offsetB = xsectAndOfs.offset2;
    * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    * (`point` to `geo::Point{ 2, 1, 0 }`, `offsetA` to `2` and `offsetB` to `1`,
    * because the intersection point is always on the first line).
    * 
    */
   template <typename Point, typename UnitVector>
-  std::tuple<Point, double, double> LineClosestPointAndOffsetsWithUnitVectors(
+  IntersectionPointAndOffsets<Point> LineClosestPointAndOffsetsWithUnitVectors(
     Point const& startA, UnitVector const& dirA,
     Point const& startB, UnitVector const& dirB
     );

--- a/larcorealg/Geometry/LineClosestPoint.h
+++ b/larcorealg/Geometry/LineClosestPoint.h
@@ -31,8 +31,56 @@ namespace geo {
    * @param dirA the direction of the first line
    * @param refB a reference point on the second line
    * @param dirB the direction of the second line
-   * @param[out] locOnLines pointer to additional output (see description)
+   * @return a triplet: `<0>`: the point of `A` closest to `B`,
+   *         `<1>`: its offset on `A` in units of `dirA`,
+   *         `<2>`: its offset on `B` in units of `dirB`
+   * @see `LineClosestPointWithUnitVectors()`
+   * @see `LineClosestPointAndOffsets()`
+   *
+   * The point of line `A` that is closest to line `B` is returned.
+   * 
+   * This function is equivalent to `LineClosestPoint()`, but it
+   * returns in addition the offsets of the intersection point from the
+   * reference points of the two lines, in the direction specified by
+   * `dirA`/`dirB`.
+   * 
+   * The return value is a triplet, which is most easily unpacked immediately:
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+   * auto [ point, offsetA, offsetB ] = geo::LineClosestPointAndOffsets(
+   *   geo::Point_t{ 2, 0, 1 }, geo::Vector_t{ 0.0,   0.5, 0.0 },
+   *   geo::Point_t{ 0, 1, 0 }, geo::Vector_t{ 0.866, 0.0, 0.0 }
+   *   );
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * will set `point` to `geo::Point{ 2, 1, 1 }`, `offsetA` to `2` and `offsetB`
+   * to `2.309...`.
+   * To reassign the variables after they have been defined, instead:
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+   * std::tie(point, offsetA, offsetB) = geo::LineClosestPointAndOffsets(
+   *   geo::Point_t{ 0, 1, 0 }, geo::Vector_t{ 0.866, 0.0, 0.0 },
+   *   geo::Point_t{ 2, 0, 1 }, geo::Vector_t{ 0.0,   0.5, 0.0 }
+   *   );
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * (`point` to `geo::Point{ 2, 1, 0 }`, `offsetA` to `2.039...` and `offsetB`
+   * to `2`, because the intersection point is always on the first line).
+   * 
+   */
+  template <typename Point, typename Vector>
+  std::tuple<Point, double, double> LineClosestPointAndOffsets(
+    Point const& startA, Vector const& dirA,
+    Point const& startB, Vector const& dirB
+    );
+  
+  
+  /**
+   * @brief Returns the point of a line that is closest to a second line.
+   * @tparam Point a type describing a point
+   * @tparam Vector a type describing a direction (displacement vector)
+   * @param refA a reference point on the first line
+   * @param dirA the direction of the first line
+   * @param refB a reference point on the second line
+   * @param dirB the direction of the second line
    * @return the point of `A` closest to `B`
+   * @see LineClosestPointAndOffsets(), LineClosestPointWithUnitVectors()
    *
    * The point of line `A` that is closest to line `B` is returned.
    * 
@@ -42,9 +90,8 @@ namespace geo {
    * @note This formulation is valid for lines in a Euclidean space of any
    *       dimension; the minimized distance is the Euclidean one.
    * 
-   * If `locOnLines` is specified, a pair is returned with the distance of the
-   * closest point from the reference points on line A (`first`) and B
-   * (`second`), in units of `dirA` and `dirB` respectively.
+   * A separate function, `LineClosestPointAndOffsets()`,
+   * also returns the offset of the intersection from the two reference points.
    * 
    * 
    * Requirements
@@ -64,8 +111,7 @@ namespace geo {
   template <typename Point, typename Vector>
   Point LineClosestPoint(
     Point const& startA, Vector const& dirA,
-    Point const& startB, Vector const& dirB,
-    std::pair<double, double>* locOnLines = nullptr
+    Point const& startB, Vector const& dirB
     );
 
   
@@ -77,8 +123,51 @@ namespace geo {
    * @param dirA the direction of the first line (unity-normed)
    * @param refB a reference point on the second line
    * @param dirB the direction of the second line (unity-normed)
-   * @param[out] locOnLines pointer to additional output (see description)
+   * @return a triplet: `<0>`: the point of `A` closest to `B`,
+   *         `<1>`: its offset on `A` in units of `dirA` (i.e. unity),
+   *         `<2>`: its offset on `B` in units of `dirB` (i.e. unity)
+   * @see `LineClosestPointWithUnitVectors()`
+   * @see `LineClosestPointAndOffsets()`
+   *
+   * The point of line `A` that is closest to line `B` is returned.
+   * 
+   * The return value is a triplet, which is most easily unpacked immediately:
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+   * auto [ point, offsetA, offsetB ] = geo::LineClosestPointAndOffsetsWithUnitVectors(
+   *   geo::Point_t{ 2, 0, 1 }, geo::Vector_t{ 0, 1, 0 },
+   *   geo::Point_t{ 0, 1, 0 }, geo::Vector_t{ 1, 0, 0 }
+   *   );
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * will set `point` to `geo::Point{ 2, 1, 1 }`, `offsetA` to `1` and `offsetB`
+   * to `2`.
+   * To reassign the variables after they have been defined, instead:
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+   * std::tie(point, offsetA, offsetB) = geo::LineClosestPointAndOffsetsWithUnitVectors(
+   *   geo::Point_t{ 0, 1, 0 }, geo::Vector_t{ 1, 0, 0 },
+   *   geo::Point_t{ 2, 0, 1 }, geo::Vector_t{ 0, 1, 0 }
+   *   );
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * (`point` to `geo::Point{ 2, 1, 0 }`, `offsetA` to `2` and `offsetB` to `1`,
+   * because the intersection point is always on the first line).
+   * 
+   */
+  template <typename Point, typename UnitVector>
+  std::tuple<Point, double, double> LineClosestPointAndOffsetsWithUnitVectors(
+    Point const& startA, UnitVector const& dirA,
+    Point const& startB, UnitVector const& dirB
+    );
+  
+  
+  /**
+   * @brief Returns the point of a line that is closest to a second line.
+   * @tparam Point a type describing a point
+   * @tparam UnitVector a type describing a direction (unit vector)
+   * @param refA a reference point on the first line
+   * @param dirA the direction of the first line (unity-normed)
+   * @param refB a reference point on the second line
+   * @param dirB the direction of the second line (unity-normed)
    * @return the point of `A` closest to `B`
+   * @see LineClosestPointAndOffsetsWithUnitVectors(), LineClosestPoint()
    *
    * The point of line `A` that is closest to line `B` is returned.
    * 
@@ -94,9 +183,8 @@ namespace geo {
    * @note This formulation is valid for lines in a Euclidean space of any
    *       dimension; the minimized distance is the Euclidean one.
    * 
-   * If `locOnLines` is specified, a pair is returned with the distance of the
-   * closest point from the reference points on line A (`first`) and B
-   * (`second`), in the same space units as the points and vectors.
+   * A separate function, `LineClosestPointAndOffsetsWithUnitVectors()`,
+   * also returne the offset of the intersection from the two reference points.
    * 
    * 
    * Requirements
@@ -119,8 +207,7 @@ namespace geo {
   template <typename Point, typename UnitVector>
   Point LineClosestPointWithUnitVectors(
     Point const& startA, UnitVector const& dirA,
-    Point const& startB, UnitVector const& dirB,
-    std::pair<double, double>* locOnLines = nullptr
+    Point const& startB, UnitVector const& dirB
     );
   
   

--- a/larcorealg/Geometry/LineClosestPoint.tcc
+++ b/larcorealg/Geometry/LineClosestPoint.tcc
@@ -17,6 +17,7 @@
 #include "larcorealg/Geometry/geo_vectors_utils.h" // geo::vect::dot()
 
 // C++ standard library
+#include <tuple> // std::tie()
 #include <cmath> // std::abs()
 #include <cassert>
 
@@ -48,11 +49,8 @@ Point geo::LineClosestPoint(
    */
 
   // aliases for quick notation
-  Point const& c1 = startA;
-  Vector const& w1 = dirA;
-
-  Point const& c2 = startB;
-  Vector const& w2 = dirB;
+  auto const& [ c1, w1 ] = std::tie(startA, dirA);
+  auto const& [ c2, w2 ] = std::tie(startB, dirB);
 
   auto const dc = c2 - c1;
 

--- a/larcorealg/Geometry/LineClosestPoint.tcc
+++ b/larcorealg/Geometry/LineClosestPoint.tcc
@@ -1,0 +1,129 @@
+/**
+ * @file   larcorealg/Geometry/LineClosestPoint.tcc
+ * @brief  Utility for intersection of two 3D lines: template implementation.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @see    larcorealg/Geometry/LineClosestPoint.h
+ */
+
+#ifndef LARCOREALG_GEOMETRY_LINECLOSESTPOINT_H
+# error "LineClosestPoint.tcc should not be included directly: #include \"larcorealg/Geometry/LineClosestPoint.h\" instead."
+#endif
+
+
+// LArSoft and framework libraries
+#include "cetlib/pow.h" // cet::square
+
+// C/C++ libraries
+#include "larcorealg/Geometry/geo_vectors_utils.h" // geo::vect::dot()
+
+// C++ standard library
+#include <cmath> // std::abs()
+#include <cassert>
+
+
+// -----------------------------------------------------------------------------
+template <typename Point, typename Vector>
+Point geo::LineClosestPoint(
+  Point const& startA, Vector const& dirA,
+  Point const& startB, Vector const& dirB,
+  std::pair<double, double>* locOnLines /* = nullptr */
+) {
+  /*
+   * The point on the first line ("A"):
+   *
+   *     p1(t) = c1 + t w1 (c1 the starting point, w1 its direction)
+   *
+   * has the minimal distance from the other line (c2 + u w2, with the same
+   * notation) at
+   *
+   *     t = [-(dc,w1)(w2,w2) + (dc,w2)(w1,w2)] / [ (w1,w2)^2 - (w1,w1)(w2,w2) ]
+   *     u = [ (dc,w2)(w2,w2) - (dc,w1)(w1,w2)] / [ (w1,w2)^2 - (w1,w1)(w2,w2) ]
+   *
+   * (where (a,b) is a scalar product and dc = (c1 - c2) ).
+   * If w1 and w2 are unit vectors, t and u are in fact the distance of the
+   * point from the "start" of the respective lines in "standard" geometry
+   * units.
+   * 
+   * If `locOnLines` is non-null, it is filled with { t, u }.
+   */
+
+  // aliases for quick notation
+  Point const& c1 = startA;
+  Vector const& w1 = dirA;
+
+  Point const& c2 = startB;
+  Vector const& w2 = dirB;
+
+  auto const dc = c2 - c1;
+
+  using geo::vect::dot;
+  double const dcw1 = dot(dc, w1);
+  double const dcw2 = dot(dc, w2);
+  double const w1w2 = dot(w1, w2); // this is cos(angle), angle between lines
+  assert(std::abs(std::abs(w1w2) - 1.0) >= 1e-10); // prerequisite: not parallel
+
+  using geo::vect::mag2;
+  double const w1w1 = mag2(w1);
+  double const w2w2 = mag2(w2);
+  double const inv_den = 1.0 / (cet::square(w1w2) - (w1w1 * w2w2));
+  double const t = ((dcw2 * w1w2) - (dcw1 * w2w2)) * inv_den;
+
+  if (locOnLines) {
+    double const u = ((dcw2 * w1w1) - (dcw1 * w1w2)) * inv_den;
+    *locOnLines = { t, u };
+  }
+
+  return c1 + w1 * t;
+
+} // geo::LineClosestPoint()
+
+
+// -----------------------------------------------------------------------------
+template <typename Point, typename UnitVector>
+Point geo::LineClosestPointWithUnitVectors(
+  Point const& startA, UnitVector const& dirA,
+  Point const& startB, UnitVector const& dirB,
+  std::pair<double, double>* locOnLines /* = nullptr */
+) {
+  /*
+   * The implementation is the same as in `LineClosestPoint()`,
+   * with some computation skipped while relying on the assumption of unit
+   * vectors.
+   */
+  
+  using geo::vect::mag2;
+  assert(std::abs(mag2(dirA) - 1.0) < 1e-10); // prerequisite: dirA unit vector
+  assert(std::abs(mag2(dirB) - 1.0) < 1e-10); // prerequisite: dirB unit vector
+
+  // aliases for quick notation
+  Point const& c1 = startA;
+  UnitVector const& w1 = dirA;
+
+  Point const& c2 = startB;
+  UnitVector const& w2 = dirB;
+
+  auto const dc = c2 - c1;
+
+  using geo::vect::dot;
+  double const dcw1 = dot(dc, w1);
+  double const dcw2 = dot(dc, w2);
+  double const w1w2 = dot(w1, w2); // this is cos(angle), angle between lines
+  assert(std::abs(std::abs(w1w2) - 1.0) >= 1e-10); // prerequisite: not parallel
+
+  // we keep the generic math here, but freeze the modulus parameters
+  constexpr double const w1w1 { 1.0 };
+  constexpr double const w2w2 { 1.0 };
+  double const inv_den = 1.0 / (cet::square(w1w2) - (w1w1 * w2w2));
+  double const t = ((dcw2 * w1w2) - (dcw1 * w2w2)) * inv_den;
+
+  if (locOnLines) {
+    double const u = ((dcw2 * w1w1) - (dcw1 * w1w2)) * inv_den;
+    *locOnLines = { t, u };
+  }
+
+  return c1 + w1 * t;
+
+} // geo::LineClosestPointWithUnitVectors()
+
+
+// -----------------------------------------------------------------------------

--- a/larcorealg/Geometry/LineClosestPoint.tcc
+++ b/larcorealg/Geometry/LineClosestPoint.tcc
@@ -23,105 +23,166 @@
 
 
 // -----------------------------------------------------------------------------
+// ---  implementation details
+// -----------------------------------------------------------------------------
+namespace geo::details {
+  
+  template <typename Point, typename Vector>
+  Point LineClosestPointImpl(
+    Point const& startA, Vector const& dirA,
+    Point const& startB, Vector const& dirB,
+    std::pair<double, double>* locOnLines /* = nullptr */
+  ) {
+    /*
+     * The point on the first line ("A"):
+     *
+     *     p1(t) = c1 + t w1 (c1 the starting point, w1 its direction)
+     *
+     * has the minimal distance from the other line (c2 + u w2, with the same
+     * notation) at
+     *
+     *     t = [-(dc,w1)(w2,w2) + (dc,w2)(w1,w2)] / [ (w1,w2)^2 - (w1,w1)(w2,w2) ]
+     *     u = [ (dc,w2)(w2,w2) - (dc,w1)(w1,w2)] / [ (w1,w2)^2 - (w1,w1)(w2,w2) ]
+     *
+     * (where (a,b) is a scalar product and dc = (c1 - c2) ).
+     * If w1 and w2 are unit vectors, t and u are in fact the distance of the
+     * point from the "start" of the respective lines in "standard" geometry
+     * units.
+     * 
+     * If `locOnLines` is non-null, it is filled with { t, u }.
+     */
+
+    // aliases for quick notation
+    auto const& [ c1, w1 ] = std::tie(startA, dirA);
+    auto const& [ c2, w2 ] = std::tie(startB, dirB);
+
+    auto const dc = c2 - c1;
+
+    using geo::vect::dot;
+    double const dcw1 = dot(dc, w1);
+    double const dcw2 = dot(dc, w2);
+    double const w1w2 = dot(w1, w2); // this is cos(angle), angle between lines
+    assert(std::abs(std::abs(w1w2) - 1.0) >= 1e-10); // prerequisite: not parallel
+
+    using geo::vect::mag2;
+    double const w1w1 = mag2(w1);
+    double const w2w2 = mag2(w2);
+    double const inv_den = 1.0 / (cet::square(w1w2) - (w1w1 * w2w2));
+    double const t = ((dcw2 * w1w2) - (dcw1 * w2w2)) * inv_den;
+
+    if (locOnLines) {
+      double const u = ((dcw2 * w1w1) - (dcw1 * w1w2)) * inv_den;
+      *locOnLines = { t, u };
+    }
+
+    return c1 + w1 * t;
+
+  } // geo::details::LineClosestPointImpl()
+
+
+  // ---------------------------------------------------------------------------
+  template <typename Point, typename UnitVector>
+  Point LineClosestPointWithUnitVectorsImpl(
+    Point const& startA, UnitVector const& dirA,
+    Point const& startB, UnitVector const& dirB,
+    std::pair<double, double>* locOnLines /* = nullptr */
+  ) {
+    /*
+     * The implementation is the same as in `LineClosestPoint()`,
+     * with some computation skipped while relying on the assumption of unit
+     * vectors.
+     */
+    
+    using geo::vect::mag2;
+    assert(std::abs(mag2(dirA) - 1.0) < 1e-10); // prerequisite: dirA unit vector
+    assert(std::abs(mag2(dirB) - 1.0) < 1e-10); // prerequisite: dirB unit vector
+  
+    // aliases for quick notation
+    Point const& c1 = startA;
+    UnitVector const& w1 = dirA;
+  
+    Point const& c2 = startB;
+    UnitVector const& w2 = dirB;
+  
+    auto const dc = c2 - c1;
+  
+    using geo::vect::dot;
+    double const dcw1 = dot(dc, w1);
+    double const dcw2 = dot(dc, w2);
+    double const w1w2 = dot(w1, w2); // this is cos(angle), angle between lines
+    assert(std::abs(std::abs(w1w2) - 1.0) >= 1e-10); // prerequisite: not parallel
+  
+    // we keep the generic math here, but freeze the modulus parameters
+    constexpr double const w1w1 { 1.0 };
+    constexpr double const w2w2 { 1.0 };
+    double const inv_den = 1.0 / (cet::square(w1w2) - (w1w1 * w2w2));
+    double const t = ((dcw2 * w1w2) - (dcw1 * w2w2)) * inv_den;
+  
+    if (locOnLines) {
+      double const u = ((dcw2 * w1w1) - (dcw1 * w1w2)) * inv_den;
+      *locOnLines = { t, u };
+    }
+  
+    return c1 + w1 * t;
+  
+  } // geo::details::LineClosestPointWithUnitVectorsImpl()
+  
+  
+  // ---------------------------------------------------------------------------
+  
+} // namespace geo::details
+
+
+// -----------------------------------------------------------------------------
+// ---  interface
+// -----------------------------------------------------------------------------
+template <typename Point, typename Vector>
+std::tuple<Point, double, double> geo::LineClosestPointAndOffsets(
+  Point const& startA, Vector const& dirA,
+  Point const& startB, Vector const& dirB
+) {
+  std::pair<double, double> locOnLines;
+  auto const point
+    = details::LineClosestPointImpl(startA, dirA, startB, dirB, &locOnLines);
+  return { point, locOnLines.first, locOnLines.second };
+} // geo::LineClosestPointAndOffsets()
+
+
+// -----------------------------------------------------------------------------
 template <typename Point, typename Vector>
 Point geo::LineClosestPoint(
   Point const& startA, Vector const& dirA,
-  Point const& startB, Vector const& dirB,
-  std::pair<double, double>* locOnLines /* = nullptr */
+  Point const& startB, Vector const& dirB
 ) {
-  /*
-   * The point on the first line ("A"):
-   *
-   *     p1(t) = c1 + t w1 (c1 the starting point, w1 its direction)
-   *
-   * has the minimal distance from the other line (c2 + u w2, with the same
-   * notation) at
-   *
-   *     t = [-(dc,w1)(w2,w2) + (dc,w2)(w1,w2)] / [ (w1,w2)^2 - (w1,w1)(w2,w2) ]
-   *     u = [ (dc,w2)(w2,w2) - (dc,w1)(w1,w2)] / [ (w1,w2)^2 - (w1,w1)(w2,w2) ]
-   *
-   * (where (a,b) is a scalar product and dc = (c1 - c2) ).
-   * If w1 and w2 are unit vectors, t and u are in fact the distance of the
-   * point from the "start" of the respective lines in "standard" geometry
-   * units.
-   * 
-   * If `locOnLines` is non-null, it is filled with { t, u }.
-   */
-
-  // aliases for quick notation
-  auto const& [ c1, w1 ] = std::tie(startA, dirA);
-  auto const& [ c2, w2 ] = std::tie(startB, dirB);
-
-  auto const dc = c2 - c1;
-
-  using geo::vect::dot;
-  double const dcw1 = dot(dc, w1);
-  double const dcw2 = dot(dc, w2);
-  double const w1w2 = dot(w1, w2); // this is cos(angle), angle between lines
-  assert(std::abs(std::abs(w1w2) - 1.0) >= 1e-10); // prerequisite: not parallel
-
-  using geo::vect::mag2;
-  double const w1w1 = mag2(w1);
-  double const w2w2 = mag2(w2);
-  double const inv_den = 1.0 / (cet::square(w1w2) - (w1w1 * w2w2));
-  double const t = ((dcw2 * w1w2) - (dcw1 * w2w2)) * inv_den;
-
-  if (locOnLines) {
-    double const u = ((dcw2 * w1w1) - (dcw1 * w1w2)) * inv_den;
-    *locOnLines = { t, u };
-  }
-
-  return c1 + w1 * t;
-
+  return details::LineClosestPointImpl(startA, dirA, startB, dirB, nullptr);
 } // geo::LineClosestPoint()
+
+
+// -----------------------------------------------------------------------------
+template <typename Point, typename UnitVector>
+std::tuple<Point, double, double> geo::LineClosestPointAndOffsetsWithUnitVectors
+(
+  Point const& startA, UnitVector const& dirA,
+  Point const& startB, UnitVector const& dirB
+) {
+  
+  std::pair<double, double> locOnLines;
+  auto const point = details::LineClosestPointWithUnitVectorsImpl
+    (startA, dirA, startB, dirB, &locOnLines);
+  return { point, locOnLines.first, locOnLines.second };
+  
+}
 
 
 // -----------------------------------------------------------------------------
 template <typename Point, typename UnitVector>
 Point geo::LineClosestPointWithUnitVectors(
   Point const& startA, UnitVector const& dirA,
-  Point const& startB, UnitVector const& dirB,
-  std::pair<double, double>* locOnLines /* = nullptr */
+  Point const& startB, UnitVector const& dirB
 ) {
-  /*
-   * The implementation is the same as in `LineClosestPoint()`,
-   * with some computation skipped while relying on the assumption of unit
-   * vectors.
-   */
-  
-  using geo::vect::mag2;
-  assert(std::abs(mag2(dirA) - 1.0) < 1e-10); // prerequisite: dirA unit vector
-  assert(std::abs(mag2(dirB) - 1.0) < 1e-10); // prerequisite: dirB unit vector
-
-  // aliases for quick notation
-  Point const& c1 = startA;
-  UnitVector const& w1 = dirA;
-
-  Point const& c2 = startB;
-  UnitVector const& w2 = dirB;
-
-  auto const dc = c2 - c1;
-
-  using geo::vect::dot;
-  double const dcw1 = dot(dc, w1);
-  double const dcw2 = dot(dc, w2);
-  double const w1w2 = dot(w1, w2); // this is cos(angle), angle between lines
-  assert(std::abs(std::abs(w1w2) - 1.0) >= 1e-10); // prerequisite: not parallel
-
-  // we keep the generic math here, but freeze the modulus parameters
-  constexpr double const w1w1 { 1.0 };
-  constexpr double const w2w2 { 1.0 };
-  double const inv_den = 1.0 / (cet::square(w1w2) - (w1w1 * w2w2));
-  double const t = ((dcw2 * w1w2) - (dcw1 * w2w2)) * inv_den;
-
-  if (locOnLines) {
-    double const u = ((dcw2 * w1w1) - (dcw1 * w1w2)) * inv_den;
-    *locOnLines = { t, u };
-  }
-
-  return c1 + w1 * t;
-
-} // geo::LineClosestPointWithUnitVectors()
+  return details::LineClosestPointWithUnitVectorsImpl
+    (startA, dirA, startB, dirB, nullptr);
+}
 
 
 // -----------------------------------------------------------------------------

--- a/larcorealg/Geometry/LineClosestPoint.tcc
+++ b/larcorealg/Geometry/LineClosestPoint.tcc
@@ -137,7 +137,7 @@ namespace geo::details {
 // ---  interface
 // -----------------------------------------------------------------------------
 template <typename Point, typename Vector>
-std::tuple<Point, double, double> geo::LineClosestPointAndOffsets(
+geo::IntersectionPointAndOffsets<Point> geo::LineClosestPointAndOffsets(
   Point const& startA, Vector const& dirA,
   Point const& startB, Vector const& dirB
 ) {
@@ -160,8 +160,8 @@ Point geo::LineClosestPoint(
 
 // -----------------------------------------------------------------------------
 template <typename Point, typename UnitVector>
-std::tuple<Point, double, double> geo::LineClosestPointAndOffsetsWithUnitVectors
-(
+geo::IntersectionPointAndOffsets<Point>
+geo::LineClosestPointAndOffsetsWithUnitVectors(
   Point const& startA, UnitVector const& dirA,
   Point const& startB, UnitVector const& dirB
 ) {

--- a/larcorealg/Geometry/WireGeo.h
+++ b/larcorealg/Geometry/WireGeo.h
@@ -431,9 +431,10 @@ namespace geo {
      * @brief Returns the point of this wire that is closest to `other` wire.
      * @tparam Point the type of point returned
      * @param other the other wire
-     * @return a triplet: `<0>`: the point of this wire closest to `other`;
-     *         `<1>`: its offset on this wire [cm];
-     *         `<2>`: its offset on the `other` wire [cm]
+     * @return a data structure with three fields:
+     *         `point`: the point of this wire closest to `other`;
+     *         `offset1`: its offset on this wire [cm];
+     *         `offset2`: its offset on the `other` wire [cm]
      * @see IntersectionWith()
      *
      * The point of this wire that is closest to any point of the `other` wire
@@ -460,7 +461,7 @@ namespace geo {
      * 
      */
     template <typename Point = DefaultPoint_t>
-    std::tuple<Point, double, double> IntersectionAndOffsetsWith
+    geo::IntersectionPointAndOffsets<Point> IntersectionAndOffsetsWith
       (geo::WireGeo const& other) const;
 
     /// @}
@@ -536,9 +537,10 @@ namespace geo {
    * @brief Returns the point of `wireA` that is closest to `wireB`.
    * @param wireA the first wire
    * @param wireB the other wire
-   * @return a triplet: `<0>`: the point of `wireA` closest to `wireB`;
-   *         `<1>`: its offset on this wire [cm];
-   *         `<2>`: its offset on the `other` wire [cm]
+   * @return a data structure with three fields:
+   *         `point`: the point of `wireA` closest to `wireB`;
+   *         `offset1`: its offset on `wireA` [cm];
+   *         `offset2`: its offset on `wireB` [cm]
    * @see WiresIntersection()
    *
    * Computes the point of `wireA` that is closest to `wireB`.
@@ -562,7 +564,7 @@ namespace geo {
    * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    * 
    */
-  std::tuple<geo::Point_t, double, double> WiresIntersectionAndOffsets
+  geo::IntersectionPointAndOffsets<geo::Point_t> WiresIntersectionAndOffsets
     (geo::WireGeo const& wireA, geo::WireGeo const& wireB);
   
 
@@ -639,7 +641,7 @@ Point geo::WireGeo::IntersectionWith(geo::WireGeo const& other) const {
 
 //------------------------------------------------------------------------------
 template <typename Point /* = DefaultPoint_t */>
-std::tuple<Point, double, double> geo::WireGeo::IntersectionAndOffsetsWith
+geo::IntersectionPointAndOffsets<Point> geo::WireGeo::IntersectionAndOffsetsWith
   (geo::WireGeo const& other) const
 {
   auto const& [ point, ofsA, ofsB ] = WiresIntersectionAndOffsets(*this, other);
@@ -661,7 +663,8 @@ inline geo::Point_t geo::WiresIntersection
 
 
 //------------------------------------------------------------------------------
-inline std::tuple<geo::Point_t, double, double> geo::WiresIntersectionAndOffsets
+inline geo::IntersectionPointAndOffsets<geo::Point_t>
+geo::WiresIntersectionAndOffsets
   (geo::WireGeo const& wireA, geo::WireGeo const& wireB)
 {
   

--- a/test/Geometry/CMakeLists.txt
+++ b/test/Geometry/CMakeLists.txt
@@ -8,6 +8,12 @@ cet_test( geo_vectors_utils_test
   USE_BOOST_UNIT
   )
 
+cet_test( LineClosestPoint_test
+  LIBRARIES
+    ROOT::GenVector
+  USE_BOOST_UNIT
+  )
+
 # test libraries
 cet_make_library( LIBRARY_NAME GeometryTestLib
                   SOURCE

--- a/test/Geometry/GeometryTestAlg.cxx
+++ b/test/Geometry/GeometryTestAlg.cxx
@@ -2340,8 +2340,9 @@ namespace geo{
   //......................................................................
   void GeometryTestAlg::testWireIntersection() const {
     /*
-     * This is a test for WireIDsIntersect() and WiresIntersect() functions;
-     * that returns whether two wires intersect, and where.
+     * This is a test for geo::GeometryCore::WireIDsIntersect() and 
+     * geo::WireGeo::IntersectionWith() methods, that return whether two wires
+     * intersect, and where.
      *
      * The test strategy is to check all the TPC one by one:
      * - if a query for wires on different cryostats fails
@@ -2373,7 +2374,7 @@ namespace geo{
         } // if intersect
         try {
           // the value of result is not checked here
-          geom->WiresIntersect(geom->Wire(w1), geom->Wire(w2));
+          geom->Wire(w1).IntersectionWith(geom->Wire(w2));
         }
         catch(...) {
           MF_LOG_ERROR("GeometryTest") << "WiresIntersect() on " << w1
@@ -2395,7 +2396,7 @@ namespace geo{
         } // if intersect
         try {
           // the value of result is not checked here
-          geom->WiresIntersect(geom->Wire(w1), geom->Wire(w2));
+          geom->Wire(w1).IntersectionWith(geom->Wire(w2));
         }
         catch(...) {
           MF_LOG_ERROR("GeometryTest") << "WiresIntersect() on " << w1
@@ -2611,18 +2612,6 @@ namespace geo{
 
         geo::Point_t objXingPoint;
         
-        // test that geom->WiresIntersect() gives the same result as the already
-        // validated one from geom->WireIDsIntersect()
-        objXingPoint = geom->WiresIntersect(w1obj, w2obj);
-        if (vectorIs.nonEqual(objXingPoint, xingPoint)) {
-          MF_LOG_ERROR("GeometryTest")
-            << "WiresIntersect() gives wrong intersection for "
-            << w1 << " and " << w2
-            << ": " << objXingPoint << " vs. " << xingPoint << " (expected)";
-          ++nErrors;
-          continue;
-        }
-
         // test that geo::WiresIntersection() gives the same result as
         // the already validated one from geom->WireIDsIntersect()
         objXingPoint = geo::WiresIntersection(w1obj, w2obj);

--- a/test/Geometry/LineClosestPoint_test.cc
+++ b/test/Geometry/LineClosestPoint_test.cc
@@ -1,0 +1,198 @@
+/**
+ * @file   LineClosestPoint_test.cc
+ * @brief  Test of `LineClosestPoint.h` utilities.
+ * @author Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date   June 29, 2021
+ * @see    `larcorealg/Geometry/LineClosestPoint.h`
+ */
+
+
+// Boost libraries
+#define BOOST_TEST_MODULE ( LineClosestPoint_test )
+#include <cetlib/quiet_unit_test.hpp> // BOOST_AUTO_TEST_CASE()
+#include <boost/test/test_tools.hpp> // BOOST_CHECK(), BOOST_CHECK_CLOSE()
+
+// LArSoft libraries
+#include "larcorealg/Geometry/LineClosestPoint.h"
+#include "larcoreobj/SimpleTypesAndConstants/geo_vectors.h"
+
+// C++ standard library
+#include <utility> // std::pair<>
+#include <cmath> // std::sqrt()
+
+
+// =============================================================================
+void LineClosestPointSimple_test() {
+  
+  constexpr double tol = 0.001; // percent in CLOSE, absolute in SMALL!
+  
+  geo::Point_t const p = geo::LineClosestPoint(
+    geo::origin() - geo::Zaxis() - 3.0 * geo::Xaxis(), geo::Xaxis(),
+    geo::origin() + geo::Zaxis() + 2.0 * geo::Yaxis(), geo::Yaxis()
+    );
+  
+  BOOST_CHECK_SMALL(p.X(),       tol);
+  BOOST_CHECK_SMALL(p.Y(),       tol);
+  BOOST_CHECK_CLOSE(p.Z(), -1.0, tol);
+  
+} // LineClosestPointSimple_test()
+
+
+// -----------------------------------------------------------------------------
+void LineClosestPointSimple45_test() {
+  
+  constexpr double tol = 0.001; // absolute
+  
+  geo::Point_t const p = geo::LineClosestPoint(
+    geo::origin(),                geo::Xaxis(),
+    geo::origin() + geo::Yaxis(), (geo::Xaxis() + geo::Zaxis()) / std::sqrt(2.0)
+    );
+  
+  BOOST_CHECK_SMALL(p.X(), tol);
+  BOOST_CHECK_SMALL(p.Y(), tol);
+  BOOST_CHECK_SMALL(p.Z(), tol);
+  
+} // LineClosestPointSimple45_test()
+
+
+// -----------------------------------------------------------------------------
+void LineClosestPointWithLocOnLines_test() {
+  
+  constexpr double tol = 0.001; // percent in CLOSE, absolute in SMALL!
+  
+  std::pair<double, double> locOnLines { 0.0, 0.0 };
+  geo::Point_t const p = geo::LineClosestPoint(
+    geo::origin()                - 3.0 * geo::Xaxis(), geo::Xaxis(),
+    geo::origin() + geo::Zaxis() + 2.0 * geo::Yaxis(), geo::Yaxis(),
+    &locOnLines
+    );
+  
+  BOOST_CHECK_SMALL(p.X(), tol);
+  BOOST_CHECK_SMALL(p.Y(), tol);
+  BOOST_CHECK_SMALL(p.Z(), tol);
+  BOOST_CHECK_CLOSE(locOnLines.first,  +3.0, tol);
+  BOOST_CHECK_CLOSE(locOnLines.second, -2.0, tol);
+  
+} // LineClosestPointWithLocOnLines_test()
+
+
+// -----------------------------------------------------------------------------
+void LineClosestPointWithScaledDirs_test() {
+  
+  constexpr double tol = 0.001; // percent in CLOSE, absolute in SMALL!
+  
+  std::pair<double, double> locOnLines { 0.0, 0.0 };
+  geo::Point_t const p = geo::LineClosestPoint(
+    geo::origin()                - 3.0 * geo::Xaxis(),  2.0 * geo::Xaxis(),
+    geo::origin() + geo::Zaxis() + 2.0 * geo::Yaxis(), -2.0 * geo::Yaxis(),
+    &locOnLines
+    );
+  
+  BOOST_CHECK_SMALL(p.X(), tol);
+  BOOST_CHECK_SMALL(p.Y(), tol);
+  BOOST_CHECK_SMALL(p.Z(), tol);
+  BOOST_CHECK_CLOSE(locOnLines.first,  +3.0 /  2.0, tol);
+  BOOST_CHECK_CLOSE(locOnLines.second, -2.0 / -2.0, tol);
+  
+} // LineClosestPointWithScaledDirs_test()
+
+
+// -----------------------------------------------------------------------------
+void LineClosestPointWithNonHomogeneousDirs_test() {
+  
+  constexpr double tol = 0.001; // percent in CLOSE, absolute in SMALL!
+  
+  std::pair<double, double> locOnLines { 0.0, 0.0 };
+  geo::Point_t const p = geo::LineClosestPoint(
+    geo::origin()                - 3.0 * geo::Xaxis(),  1.5 * geo::Xaxis(),
+    geo::origin() + geo::Zaxis() + 2.0 * geo::Yaxis(), -2.0 * geo::Yaxis(),
+    &locOnLines
+    );
+  
+  BOOST_CHECK_SMALL(p.X(), tol);
+  BOOST_CHECK_SMALL(p.Y(), tol);
+  BOOST_CHECK_SMALL(p.Z(), tol);
+  BOOST_CHECK_CLOSE(locOnLines.first,  +3.0 /  1.5, tol);
+  BOOST_CHECK_CLOSE(locOnLines.second, -2.0 / -2.0, tol);
+  
+} // LineClosestPointWithNonHomogeneousDirs_test()
+
+
+// =============================================================================
+void LineClosestPointWithUnitVectorsSimple_test() {
+  
+  constexpr double tol = 0.001; // percent in CLOSE, absolute in SMALL!
+  
+  geo::Point_t const p = geo::LineClosestPointWithUnitVectors(
+    geo::origin() - geo::Zaxis() - 3.0 * geo::Xaxis(), geo::Xaxis(),
+    geo::origin() + geo::Zaxis() + 2.0 * geo::Yaxis(), geo::Yaxis()
+    );
+  
+  BOOST_CHECK_SMALL(p.X(),       tol);
+  BOOST_CHECK_SMALL(p.Y(),       tol);
+  BOOST_CHECK_CLOSE(p.Z(), -1.0, tol);
+  
+} // LineClosestPointWithUnitVectorsSimple_test()
+
+
+// -----------------------------------------------------------------------------
+void LineClosestPointWithUnitVectorsSimple45_test() {
+  
+  constexpr double tol = 0.001; // absolute
+  
+  geo::Point_t const p = geo::LineClosestPointWithUnitVectors(
+    geo::origin(),                geo::Xaxis(),
+    geo::origin() + geo::Yaxis(), (geo::Xaxis() + geo::Zaxis()) / std::sqrt(2.0)
+    );
+  
+  BOOST_CHECK_SMALL(p.X(), tol);
+  BOOST_CHECK_SMALL(p.Y(), tol);
+  BOOST_CHECK_SMALL(p.Z(), tol);
+  
+} // LineClosestPointWithUnitVectorsSimple45_test()
+
+
+// -----------------------------------------------------------------------------
+void LineClosestPointWithUnitVectorsWithLocOnLines_test() {
+  
+  constexpr double tol = 0.001; // percent in CLOSE, absolute in SMALL!
+  
+  std::pair<double, double> locOnLines { 0.0, 0.0 };
+  geo::Point_t const p = geo::LineClosestPointWithUnitVectors(
+    geo::origin()                - 3.0 * geo::Xaxis(), geo::Xaxis(),
+    geo::origin() + geo::Zaxis() + 2.0 * geo::Yaxis(), geo::Yaxis(),
+    &locOnLines
+    );
+  
+  BOOST_CHECK_SMALL(p.X(), tol);
+  BOOST_CHECK_SMALL(p.Y(), tol);
+  BOOST_CHECK_SMALL(p.Z(), tol);
+  BOOST_CHECK_CLOSE(locOnLines.first,  +3.0, tol);
+  BOOST_CHECK_CLOSE(locOnLines.second, -2.0, tol);
+  
+} // LineClosestPointWithUnitVectorsWithLocOnLines_test()
+
+
+// =============================================================================
+BOOST_AUTO_TEST_CASE(LineClosestPointTestCase) {
+  
+  LineClosestPointSimple_test();
+  LineClosestPointSimple45_test();
+  LineClosestPointWithLocOnLines_test();
+  LineClosestPointWithScaledDirs_test();
+  LineClosestPointWithNonHomogeneousDirs_test();
+  
+} // BOOST_AUTO_TEST_CASE(LineClosestPointTestCase)
+
+
+// -----------------------------------------------------------------------------
+BOOST_AUTO_TEST_CASE(LineClosestPointWithUnitVectorsTestCase) {
+  
+  LineClosestPointWithUnitVectorsSimple_test();
+  LineClosestPointWithUnitVectorsSimple45_test();
+  LineClosestPointWithUnitVectorsWithLocOnLines_test();
+  
+} // BOOST_AUTO_TEST_CASE(LineClosestPointWithUnitVectorsTestCase)
+
+
+// -----------------------------------------------------------------------------

--- a/test/Geometry/LineClosestPoint_test.cc
+++ b/test/Geometry/LineClosestPoint_test.cc
@@ -8,8 +8,8 @@
 
 
 // Boost libraries
-#define BOOST_TEST_MODULE ( LineClosestPoint_test )
-#include <cetlib/quiet_unit_test.hpp> // BOOST_AUTO_TEST_CASE()
+#define BOOST_TEST_MODULE LineClosestPoint_test
+#include <cetlib/quiet_unit_test.hpp> // BOOST_AUTO_TEST_CASE(), BOOST_TEST()
 #include <boost/test/test_tools.hpp> // BOOST_CHECK(), BOOST_CHECK_CLOSE()
 
 // LArSoft libraries
@@ -25,16 +25,16 @@
 // =============================================================================
 void LineClosestPointSimple_test() {
   
-  constexpr double tol = 0.001; // percent in CLOSE, absolute in SMALL!
+  auto const tol = boost::test_tools::tolerance(0.001);
   
   geo::Point_t const p = geo::LineClosestPoint(
     geo::origin() - geo::Zaxis() - 3.0 * geo::Xaxis(), geo::Xaxis(),
     geo::origin() + geo::Zaxis() + 2.0 * geo::Yaxis(), geo::Yaxis()
     );
   
-  BOOST_CHECK_SMALL(p.X(),       tol);
-  BOOST_CHECK_SMALL(p.Y(),       tol);
-  BOOST_CHECK_CLOSE(p.Z(), -1.0, tol);
+  BOOST_TEST(p.X() ==  0.0, tol);
+  BOOST_TEST(p.Y() ==  0.0, tol);
+  BOOST_TEST(p.Z() == -1.0, tol);
   
 } // LineClosestPointSimple_test()
 
@@ -42,16 +42,16 @@ void LineClosestPointSimple_test() {
 // -----------------------------------------------------------------------------
 void LineClosestPointSimple45_test() {
   
-  constexpr double tol = 0.001; // absolute
+  auto const tol = boost::test_tools::tolerance(0.001);
   
   geo::Point_t const p = geo::LineClosestPoint(
     geo::origin(),                geo::Xaxis(),
     geo::origin() + geo::Yaxis(), (geo::Xaxis() + geo::Zaxis()) / std::sqrt(2.0)
     );
   
-  BOOST_CHECK_SMALL(p.X(), tol);
-  BOOST_CHECK_SMALL(p.Y(), tol);
-  BOOST_CHECK_SMALL(p.Z(), tol);
+  BOOST_TEST(p.X() == 0.0, tol);
+  BOOST_TEST(p.Y() == 0.0, tol);
+  BOOST_TEST(p.Z() == 0.0, tol);
   
 } // LineClosestPointSimple45_test()
 
@@ -59,18 +59,18 @@ void LineClosestPointSimple45_test() {
 // -----------------------------------------------------------------------------
 void LineClosestPointAndOffsets_test() {
   
-  constexpr double tol = 0.001; // percent in CLOSE, absolute in SMALL!
+  auto const tol = boost::test_tools::tolerance(0.001);
   
   auto const [ p, ofsA, ofsB ] = geo::LineClosestPointAndOffsets(
     geo::origin()                - 3.0 * geo::Xaxis(), geo::Xaxis(),
     geo::origin() + geo::Zaxis() + 2.0 * geo::Yaxis(), geo::Yaxis()
     );
   
-  BOOST_CHECK_SMALL(p.X(), tol);
-  BOOST_CHECK_SMALL(p.Y(), tol);
-  BOOST_CHECK_SMALL(p.Z(), tol);
-  BOOST_CHECK_CLOSE(ofsA,  +3.0, tol);
-  BOOST_CHECK_CLOSE(ofsB, -2.0, tol);
+  BOOST_TEST(p.X() ==  0.0, tol);
+  BOOST_TEST(p.Y() ==  0.0, tol);
+  BOOST_TEST(p.Z() ==  0.0, tol);
+  BOOST_TEST(ofsA  == +3.0, tol);
+  BOOST_TEST(ofsB  == -2.0, tol);
   
 } // LineClosestPointAndOffsets_test()
 
@@ -78,18 +78,18 @@ void LineClosestPointAndOffsets_test() {
 // -----------------------------------------------------------------------------
 void LineClosestPointWithScaledDirs_test() {
   
-  constexpr double tol = 0.001; // percent in CLOSE, absolute in SMALL!
+  auto const tol = boost::test_tools::tolerance(0.001);
   
   auto const [ p, ofsA, ofsB ] = geo::LineClosestPointAndOffsets(
     geo::origin()                - 3.0 * geo::Xaxis(),  2.0 * geo::Xaxis(),
     geo::origin() + geo::Zaxis() + 2.0 * geo::Yaxis(), -2.0 * geo::Yaxis()
     );
   
-  BOOST_CHECK_SMALL(p.X(), tol);
-  BOOST_CHECK_SMALL(p.Y(), tol);
-  BOOST_CHECK_SMALL(p.Z(), tol);
-  BOOST_CHECK_CLOSE(ofsA, +3.0 /  2.0, tol);
-  BOOST_CHECK_CLOSE(ofsB, -2.0 / -2.0, tol);
+  BOOST_TEST(p.X() ==  0.0, tol);
+  BOOST_TEST(p.Y() ==  0.0, tol);
+  BOOST_TEST(p.Z() ==  0.0, tol);
+  BOOST_TEST(ofsA  == (+3.0 /  2.0), tol);
+  BOOST_TEST(ofsB  == (-2.0 / -2.0), tol);
   
 } // LineClosestPointWithScaledDirs_test()
 
@@ -97,18 +97,18 @@ void LineClosestPointWithScaledDirs_test() {
 // -----------------------------------------------------------------------------
 void LineClosestPointWithNonHomogeneousDirs_test() {
   
-  constexpr double tol = 0.001; // percent in CLOSE, absolute in SMALL!
+  auto const tol = boost::test_tools::tolerance(0.001);
   
   auto const [ p, ofsA, ofsB ] = geo::LineClosestPointAndOffsets(
     geo::origin()                - 3.0 * geo::Xaxis(),  1.5 * geo::Xaxis(),
     geo::origin() + geo::Zaxis() + 2.0 * geo::Yaxis(), -2.0 * geo::Yaxis()
     );
   
-  BOOST_CHECK_SMALL(p.X(), tol);
-  BOOST_CHECK_SMALL(p.Y(), tol);
-  BOOST_CHECK_SMALL(p.Z(), tol);
-  BOOST_CHECK_CLOSE(ofsA, +3.0 /  1.5, tol);
-  BOOST_CHECK_CLOSE(ofsB, -2.0 / -2.0, tol);
+  BOOST_TEST(p.X() ==  0.0, tol);
+  BOOST_TEST(p.Y() ==  0.0, tol);
+  BOOST_TEST(p.Z() ==  0.0, tol);
+  BOOST_TEST(ofsA  == (+3.0 /  1.5), tol);
+  BOOST_TEST(ofsB  == (-2.0 / -2.0), tol);
   
 } // LineClosestPointWithNonHomogeneousDirs_test()
 
@@ -116,7 +116,7 @@ void LineClosestPointWithNonHomogeneousDirs_test() {
 // -----------------------------------------------------------------------------
 void LineClosestPointAndOffsetsDocumentation_test() {
   
-  constexpr double tol = 0.001; // percent in CLOSE, absolute in SMALL!
+  auto const tol = boost::test_tools::tolerance(0.001);
   
   /*
    * The promise:
@@ -156,22 +156,22 @@ void LineClosestPointAndOffsetsDocumentation_test() {
   static_assert
     (std::is_same_v<decltype(offsetB), double>, "Unexpected second offset type");
   
-  BOOST_CHECK_CLOSE(point.X(), 2.0, tol);
-  BOOST_CHECK_CLOSE(point.Y(), 1.0, tol);
-  BOOST_CHECK_CLOSE(point.Z(), 1.0, tol);
-  BOOST_CHECK_CLOSE(offsetA, 2.0, tol);
-  BOOST_CHECK_CLOSE(offsetB, 2.0/0.866, tol);
+  BOOST_TEST(point.X() == 2.0, tol);
+  BOOST_TEST(point.Y() == 1.0, tol);
+  BOOST_TEST(point.Z() == 1.0, tol);
+  BOOST_TEST(offsetA   == 2.0, tol);
+  BOOST_TEST(offsetB   == (2.0/0.866), tol);
   
   std::tie(point, offsetA, offsetB) = geo::LineClosestPointAndOffsets(
     geo::Point_t{ 0, 1, 0 }, geo::Vector_t{ 0.866, 0.0, 0.0 },
     geo::Point_t{ 2, 0, 1 }, geo::Vector_t{ 0.0,   0.5, 0.0 }
     );
   
-  BOOST_CHECK_CLOSE(point.X(), 2.0, tol);
-  BOOST_CHECK_CLOSE(point.Y(), 1.0, tol);
-  BOOST_CHECK_CLOSE(point.Z(), 0.0, tol);
-  BOOST_CHECK_CLOSE(offsetA, 2.0/0.866, tol);
-  BOOST_CHECK_CLOSE(offsetB, 2.0, tol);
+  BOOST_TEST(point.X() == 2.0, tol);
+  BOOST_TEST(point.Y() == 1.0, tol);
+  BOOST_TEST(point.Z() == 0.0, tol);
+  BOOST_TEST(offsetA   == 2.0/0.866, tol);
+  BOOST_TEST(offsetB   == 2.0, tol);
   
 } // LineClosestPointAndOffsetsDocumentation_test()
 
@@ -179,16 +179,16 @@ void LineClosestPointAndOffsetsDocumentation_test() {
 // =============================================================================
 void LineClosestPointWithUnitVectorsSimple_test() {
   
-  constexpr double tol = 0.001; // percent in CLOSE, absolute in SMALL!
+  auto const tol = boost::test_tools::tolerance(0.001);
   
   geo::Point_t const p = geo::LineClosestPointWithUnitVectors(
     geo::origin() - geo::Zaxis() - 3.0 * geo::Xaxis(), geo::Xaxis(),
     geo::origin() + geo::Zaxis() + 2.0 * geo::Yaxis(), geo::Yaxis()
     );
   
-  BOOST_CHECK_SMALL(p.X(),       tol);
-  BOOST_CHECK_SMALL(p.Y(),       tol);
-  BOOST_CHECK_CLOSE(p.Z(), -1.0, tol);
+  BOOST_TEST(p.X() ==  0.0, tol);
+  BOOST_TEST(p.Y() ==  0.0, tol);
+  BOOST_TEST(p.Z() == -1.0, tol);
   
 } // LineClosestPointWithUnitVectorsSimple_test()
 
@@ -196,16 +196,16 @@ void LineClosestPointWithUnitVectorsSimple_test() {
 // -----------------------------------------------------------------------------
 void LineClosestPointWithUnitVectorsSimple45_test() {
   
-  constexpr double tol = 0.001; // absolute
+  auto const tol = boost::test_tools::tolerance(0.001);
   
   geo::Point_t const p = geo::LineClosestPointWithUnitVectors(
     geo::origin(),                geo::Xaxis(),
     geo::origin() + geo::Yaxis(), (geo::Xaxis() + geo::Zaxis()) / std::sqrt(2.0)
     );
   
-  BOOST_CHECK_SMALL(p.X(), tol);
-  BOOST_CHECK_SMALL(p.Y(), tol);
-  BOOST_CHECK_SMALL(p.Z(), tol);
+  BOOST_TEST(p.X() == 0.0, tol);
+  BOOST_TEST(p.Y() == 0.0, tol);
+  BOOST_TEST(p.Z() == 0.0, tol);
   
 } // LineClosestPointWithUnitVectorsSimple45_test()
 
@@ -213,18 +213,18 @@ void LineClosestPointWithUnitVectorsSimple45_test() {
 // -----------------------------------------------------------------------------
 void LineClosestPointWithUnitVectorsAndOffsets_test() {
   
-  constexpr double tol = 0.001; // percent in CLOSE, absolute in SMALL!
+  auto const tol = boost::test_tools::tolerance(0.001);
   
   auto const [ p, ofsA, ofsB ] = geo::LineClosestPointAndOffsetsWithUnitVectors(
     geo::origin()                - 3.0 * geo::Xaxis(), geo::Xaxis(),
     geo::origin() + geo::Zaxis() + 2.0 * geo::Yaxis(), geo::Yaxis()
     );
   
-  BOOST_CHECK_SMALL(p.X(), tol);
-  BOOST_CHECK_SMALL(p.Y(), tol);
-  BOOST_CHECK_SMALL(p.Z(), tol);
-  BOOST_CHECK_CLOSE(ofsA, +3.0, tol);
-  BOOST_CHECK_CLOSE(ofsB, -2.0, tol);
+  BOOST_TEST(p.X() ==  0.0, tol);
+  BOOST_TEST(p.Y() ==  0.0, tol);
+  BOOST_TEST(p.Z() ==  0.0, tol);
+  BOOST_TEST(ofsA  == +3.0, tol);
+  BOOST_TEST(ofsB  == -2.0, tol);
   
 } // LineClosestPointWithUnitVectorsAndOffsets_test()
 
@@ -232,7 +232,7 @@ void LineClosestPointWithUnitVectorsAndOffsets_test() {
 // -----------------------------------------------------------------------------
 void LineClosestPointAndOffsetsWithUnitVectorsDocumentation_test() {
   
-  constexpr double tol = 0.001; // percent in CLOSE, absolute in SMALL!
+  auto const tol = boost::test_tools::tolerance(0.001);
   
   /*
    * The promise:
@@ -272,22 +272,22 @@ void LineClosestPointAndOffsetsWithUnitVectorsDocumentation_test() {
   static_assert
     (std::is_same_v<decltype(offsetB), double>, "Unexpected second offset type");
   
-  BOOST_CHECK_CLOSE(point.X(), 2.0, tol);
-  BOOST_CHECK_CLOSE(point.Y(), 1.0, tol);
-  BOOST_CHECK_CLOSE(point.Z(), 1.0, tol);
-  BOOST_CHECK_CLOSE(offsetA, 1.0, tol);
-  BOOST_CHECK_CLOSE(offsetB, 2.0, tol);
+  BOOST_TEST(point.X() == 2.0, tol);
+  BOOST_TEST(point.Y() == 1.0, tol);
+  BOOST_TEST(point.Z() == 1.0, tol);
+  BOOST_TEST(offsetA   == 1.0, tol);
+  BOOST_TEST(offsetB   == 2.0, tol);
   
   std::tie(point, offsetA, offsetB) = geo::LineClosestPointAndOffsetsWithUnitVectors(
     geo::Point_t{ 0, 1, 0 }, geo::Vector_t{ 1, 0, 0 },
     geo::Point_t{ 2, 0, 1 }, geo::Vector_t{ 0, 1, 0 }
     );
   
-  BOOST_CHECK_CLOSE(point.X(), 2.0, tol);
-  BOOST_CHECK_CLOSE(point.Y(), 1.0, tol);
-  BOOST_CHECK_CLOSE(point.Z(), 0.0, tol);
-  BOOST_CHECK_CLOSE(offsetA, 2.0, tol);
-  BOOST_CHECK_CLOSE(offsetB, 1.0, tol);
+  BOOST_TEST(point.X() == 2.0, tol);
+  BOOST_TEST(point.Y() == 1.0, tol);
+  BOOST_TEST(point.Z() == 0.0, tol);
+  BOOST_TEST(offsetA   == 2.0, tol);
+  BOOST_TEST(offsetB   == 1.0, tol);
   
 } // LineClosestPointAndOffsetsWithUnitVectorsDocumentation_test()
 

--- a/test/Geometry/LineClosestPoint_test.cc
+++ b/test/Geometry/LineClosestPoint_test.cc
@@ -179,6 +179,18 @@ void LineClosestPointAndOffsetsDocumentation_test() {
   BOOST_TEST(offsetA   == 2.0/0.866, tol);
   BOOST_TEST(offsetB   == 2.0, tol);
   
+  // actually we _can_ assign with `std::tie()`:
+  std::tie(point, offsetA, offsetB) = geo::LineClosestPointAndOffsets(
+    geo::Point_t{ 2, 0, 1 }, geo::Vector_t{ 0.0,   0.5, 0.0 },
+    geo::Point_t{ 0, 1, 0 }, geo::Vector_t{ 0.866, 0.0, 0.0 }
+    );
+  
+  BOOST_TEST(point.X() == 2.0, tol);
+  BOOST_TEST(point.Y() == 1.0, tol);
+  BOOST_TEST(point.Z() == 1.0, tol);
+  BOOST_TEST(offsetA   == 2.0, tol);
+  BOOST_TEST(offsetB   == (2.0/0.866), tol);
+  
 } // LineClosestPointAndOffsetsDocumentation_test()
 
 
@@ -300,6 +312,18 @@ void LineClosestPointAndOffsetsWithUnitVectorsDocumentation_test() {
   BOOST_TEST(point.Z() == 0.0, tol);
   BOOST_TEST(offsetA   == 2.0, tol);
   BOOST_TEST(offsetB   == 1.0, tol);
+  
+  // actually we _can_ assign with `std::tie()`:
+  std::tie(point, offsetA, offsetB) = geo::LineClosestPointAndOffsetsWithUnitVectors(
+    geo::Point_t{ 2, 0, 1 }, geo::Vector_t{ 0, 1, 0 },
+    geo::Point_t{ 0, 1, 0 }, geo::Vector_t{ 1, 0, 0 }
+    );
+  
+  BOOST_TEST(point.X() == 2.0, tol);
+  BOOST_TEST(point.Y() == 1.0, tol);
+  BOOST_TEST(point.Z() == 1.0, tol);
+  BOOST_TEST(offsetA   == 1.0, tol);
+  BOOST_TEST(offsetB   == 2.0, tol);
   
 } // LineClosestPointAndOffsetsWithUnitVectorsDocumentation_test()
 

--- a/test/Geometry/LineClosestPoint_test.cc
+++ b/test/Geometry/LineClosestPoint_test.cc
@@ -18,6 +18,7 @@
 
 // C++ standard library
 #include <utility> // std::pair<>
+#include <type_traits> // std::is_same_v<>
 #include <cmath> // std::sqrt()
 
 
@@ -56,24 +57,22 @@ void LineClosestPointSimple45_test() {
 
 
 // -----------------------------------------------------------------------------
-void LineClosestPointWithLocOnLines_test() {
+void LineClosestPointAndOffsets_test() {
   
   constexpr double tol = 0.001; // percent in CLOSE, absolute in SMALL!
   
-  std::pair<double, double> locOnLines { 0.0, 0.0 };
-  geo::Point_t const p = geo::LineClosestPoint(
+  auto const [ p, ofsA, ofsB ] = geo::LineClosestPointAndOffsets(
     geo::origin()                - 3.0 * geo::Xaxis(), geo::Xaxis(),
-    geo::origin() + geo::Zaxis() + 2.0 * geo::Yaxis(), geo::Yaxis(),
-    &locOnLines
+    geo::origin() + geo::Zaxis() + 2.0 * geo::Yaxis(), geo::Yaxis()
     );
   
   BOOST_CHECK_SMALL(p.X(), tol);
   BOOST_CHECK_SMALL(p.Y(), tol);
   BOOST_CHECK_SMALL(p.Z(), tol);
-  BOOST_CHECK_CLOSE(locOnLines.first,  +3.0, tol);
-  BOOST_CHECK_CLOSE(locOnLines.second, -2.0, tol);
+  BOOST_CHECK_CLOSE(ofsA,  +3.0, tol);
+  BOOST_CHECK_CLOSE(ofsB, -2.0, tol);
   
-} // LineClosestPointWithLocOnLines_test()
+} // LineClosestPointAndOffsets_test()
 
 
 // -----------------------------------------------------------------------------
@@ -81,18 +80,16 @@ void LineClosestPointWithScaledDirs_test() {
   
   constexpr double tol = 0.001; // percent in CLOSE, absolute in SMALL!
   
-  std::pair<double, double> locOnLines { 0.0, 0.0 };
-  geo::Point_t const p = geo::LineClosestPoint(
+  auto const [ p, ofsA, ofsB ] = geo::LineClosestPointAndOffsets(
     geo::origin()                - 3.0 * geo::Xaxis(),  2.0 * geo::Xaxis(),
-    geo::origin() + geo::Zaxis() + 2.0 * geo::Yaxis(), -2.0 * geo::Yaxis(),
-    &locOnLines
+    geo::origin() + geo::Zaxis() + 2.0 * geo::Yaxis(), -2.0 * geo::Yaxis()
     );
   
   BOOST_CHECK_SMALL(p.X(), tol);
   BOOST_CHECK_SMALL(p.Y(), tol);
   BOOST_CHECK_SMALL(p.Z(), tol);
-  BOOST_CHECK_CLOSE(locOnLines.first,  +3.0 /  2.0, tol);
-  BOOST_CHECK_CLOSE(locOnLines.second, -2.0 / -2.0, tol);
+  BOOST_CHECK_CLOSE(ofsA, +3.0 /  2.0, tol);
+  BOOST_CHECK_CLOSE(ofsB, -2.0 / -2.0, tol);
   
 } // LineClosestPointWithScaledDirs_test()
 
@@ -102,20 +99,81 @@ void LineClosestPointWithNonHomogeneousDirs_test() {
   
   constexpr double tol = 0.001; // percent in CLOSE, absolute in SMALL!
   
-  std::pair<double, double> locOnLines { 0.0, 0.0 };
-  geo::Point_t const p = geo::LineClosestPoint(
+  auto const [ p, ofsA, ofsB ] = geo::LineClosestPointAndOffsets(
     geo::origin()                - 3.0 * geo::Xaxis(),  1.5 * geo::Xaxis(),
-    geo::origin() + geo::Zaxis() + 2.0 * geo::Yaxis(), -2.0 * geo::Yaxis(),
-    &locOnLines
+    geo::origin() + geo::Zaxis() + 2.0 * geo::Yaxis(), -2.0 * geo::Yaxis()
     );
   
   BOOST_CHECK_SMALL(p.X(), tol);
   BOOST_CHECK_SMALL(p.Y(), tol);
   BOOST_CHECK_SMALL(p.Z(), tol);
-  BOOST_CHECK_CLOSE(locOnLines.first,  +3.0 /  1.5, tol);
-  BOOST_CHECK_CLOSE(locOnLines.second, -2.0 / -2.0, tol);
+  BOOST_CHECK_CLOSE(ofsA, +3.0 /  1.5, tol);
+  BOOST_CHECK_CLOSE(ofsB, -2.0 / -2.0, tol);
   
 } // LineClosestPointWithNonHomogeneousDirs_test()
+
+
+// -----------------------------------------------------------------------------
+void LineClosestPointAndOffsetsDocumentation_test() {
+  
+  constexpr double tol = 0.001; // percent in CLOSE, absolute in SMALL!
+  
+  /*
+   * The promise:
+   * 
+   * --- 8< --------------------------------------------------------------------
+   * The return value is a triplet, which is most easily unpacked immediately:
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+   * auto [ point, offsetA, offsetB ] = geo::LineClosestPointAndOffsets(
+   *   geo::Point_t{ 2, 0, 1 }, geo::Vector_t{ 0.0,   0.5, 0.0 },
+   *   geo::Point_t{ 0, 1, 0 }, geo::Vector_t{ 0.866, 0.0, 0.0 }
+   *   );
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * will set `point` to `geo::Point{ 2, 1, 1 }`, `offsetA` to `2` and `offsetB`
+   * to `2.309...`.
+   * To reassign the variables after they have been defined, instead:
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+   * std::tie(point, offsetA, offsetB) = geo::LineClosestPointAndOffsets(
+   *   geo::Point_t{ 0, 1, 0 }, geo::Vector_t{ 0.866, 0.0, 0.0 },
+   *   geo::Point_t{ 2, 0, 1 }, geo::Vector_t{ 0.0,   0.5, 0.0 }
+   *   );
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * (`point` to `geo::Point{ 2, 1, 0 }`, `offsetA` to `2.039...` and `offsetB`
+   * to `2`, because the intersection point is always on the first line).
+   * --- 8< --------------------------------------------------------------------
+   */
+  
+  auto [ point, offsetA, offsetB ] = geo::LineClosestPointAndOffsets(
+    geo::Point_t{ 2, 0, 1 }, geo::Vector_t{ 0.0,   0.5, 0.0 },
+    geo::Point_t{ 0, 1, 0 }, geo::Vector_t{ 0.866, 0.0, 0.0 }
+    );
+  
+  // a way to check we did not mess with the assignment above too much
+  static_assert
+    (std::is_same_v<decltype(point), geo::Point_t>, "Unexpected point type");
+  static_assert
+    (std::is_same_v<decltype(offsetA), double>, "Unexpected first offset type");
+  static_assert
+    (std::is_same_v<decltype(offsetB), double>, "Unexpected second offset type");
+  
+  BOOST_CHECK_CLOSE(point.X(), 2.0, tol);
+  BOOST_CHECK_CLOSE(point.Y(), 1.0, tol);
+  BOOST_CHECK_CLOSE(point.Z(), 1.0, tol);
+  BOOST_CHECK_CLOSE(offsetA, 2.0, tol);
+  BOOST_CHECK_CLOSE(offsetB, 2.0/0.866, tol);
+  
+  std::tie(point, offsetA, offsetB) = geo::LineClosestPointAndOffsets(
+    geo::Point_t{ 0, 1, 0 }, geo::Vector_t{ 0.866, 0.0, 0.0 },
+    geo::Point_t{ 2, 0, 1 }, geo::Vector_t{ 0.0,   0.5, 0.0 }
+    );
+  
+  BOOST_CHECK_CLOSE(point.X(), 2.0, tol);
+  BOOST_CHECK_CLOSE(point.Y(), 1.0, tol);
+  BOOST_CHECK_CLOSE(point.Z(), 0.0, tol);
+  BOOST_CHECK_CLOSE(offsetA, 2.0/0.866, tol);
+  BOOST_CHECK_CLOSE(offsetB, 2.0, tol);
+  
+} // LineClosestPointAndOffsetsDocumentation_test()
 
 
 // =============================================================================
@@ -153,24 +211,85 @@ void LineClosestPointWithUnitVectorsSimple45_test() {
 
 
 // -----------------------------------------------------------------------------
-void LineClosestPointWithUnitVectorsWithLocOnLines_test() {
+void LineClosestPointWithUnitVectorsAndOffsets_test() {
   
   constexpr double tol = 0.001; // percent in CLOSE, absolute in SMALL!
   
-  std::pair<double, double> locOnLines { 0.0, 0.0 };
-  geo::Point_t const p = geo::LineClosestPointWithUnitVectors(
+  auto const [ p, ofsA, ofsB ] = geo::LineClosestPointAndOffsetsWithUnitVectors(
     geo::origin()                - 3.0 * geo::Xaxis(), geo::Xaxis(),
-    geo::origin() + geo::Zaxis() + 2.0 * geo::Yaxis(), geo::Yaxis(),
-    &locOnLines
+    geo::origin() + geo::Zaxis() + 2.0 * geo::Yaxis(), geo::Yaxis()
     );
   
   BOOST_CHECK_SMALL(p.X(), tol);
   BOOST_CHECK_SMALL(p.Y(), tol);
   BOOST_CHECK_SMALL(p.Z(), tol);
-  BOOST_CHECK_CLOSE(locOnLines.first,  +3.0, tol);
-  BOOST_CHECK_CLOSE(locOnLines.second, -2.0, tol);
+  BOOST_CHECK_CLOSE(ofsA, +3.0, tol);
+  BOOST_CHECK_CLOSE(ofsB, -2.0, tol);
   
-} // LineClosestPointWithUnitVectorsWithLocOnLines_test()
+} // LineClosestPointWithUnitVectorsAndOffsets_test()
+
+
+// -----------------------------------------------------------------------------
+void LineClosestPointAndOffsetsWithUnitVectorsDocumentation_test() {
+  
+  constexpr double tol = 0.001; // percent in CLOSE, absolute in SMALL!
+  
+  /*
+   * The promise:
+   * 
+   * --- 8< --------------------------------------------------------------------
+   * The return value is a triplet, which is most easily unpacked immediately:
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+   * auto [ point, offsetA, offsetB ] = geo::LineClosestPointAndOffsetsWithUnitVectors(
+   *   geo::Point_t{ 2, 0, 1 }, geo::Vector_t{ 0, 1, 0 },
+   *   geo::Point_t{ 0, 1, 0 }, geo::Vector_t{ 1, 0, 0 }
+   *   );
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * will set `point` to `geo::Point{ 2, 1, 1 }`, `offsetA` to `1` and `offsetB`
+   * to `2`.
+   * To reassign the variables after they have been defined, instead:
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+   * std::tie(point, offsetA, offsetB) = geo::LineClosestPointAndOffsetsWithUnitVectors(
+   *   geo::Point_t{ 0, 1, 0 }, geo::Vector_t{ 1, 0, 0 },
+   *   geo::Point_t{ 2, 0, 1 }, geo::Vector_t{ 0, 1, 0 }
+   *   );
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * (`point` to `geo::Point{ 2, 1, 0 }`, `offsetA` to `2` and `offsetB` to `1`,
+   * because the intersection point is always on the first line).
+   * --- 8< --------------------------------------------------------------------
+   */
+  
+  auto [ point, offsetA, offsetB ] = geo::LineClosestPointAndOffsetsWithUnitVectors(
+    geo::Point_t{ 2, 0, 1 }, geo::Vector_t{ 0, 1, 0 },
+    geo::Point_t{ 0, 1, 0 }, geo::Vector_t{ 1, 0, 0 }
+    );
+  
+  // a way to check we did not mess with the assignment above too much
+  static_assert
+    (std::is_same_v<decltype(point), geo::Point_t>, "Unexpected point type");
+  static_assert
+    (std::is_same_v<decltype(offsetA), double>, "Unexpected first offset type");
+  static_assert
+    (std::is_same_v<decltype(offsetB), double>, "Unexpected second offset type");
+  
+  BOOST_CHECK_CLOSE(point.X(), 2.0, tol);
+  BOOST_CHECK_CLOSE(point.Y(), 1.0, tol);
+  BOOST_CHECK_CLOSE(point.Z(), 1.0, tol);
+  BOOST_CHECK_CLOSE(offsetA, 1.0, tol);
+  BOOST_CHECK_CLOSE(offsetB, 2.0, tol);
+  
+  std::tie(point, offsetA, offsetB) = geo::LineClosestPointAndOffsetsWithUnitVectors(
+    geo::Point_t{ 0, 1, 0 }, geo::Vector_t{ 1, 0, 0 },
+    geo::Point_t{ 2, 0, 1 }, geo::Vector_t{ 0, 1, 0 }
+    );
+  
+  BOOST_CHECK_CLOSE(point.X(), 2.0, tol);
+  BOOST_CHECK_CLOSE(point.Y(), 1.0, tol);
+  BOOST_CHECK_CLOSE(point.Z(), 0.0, tol);
+  BOOST_CHECK_CLOSE(offsetA, 2.0, tol);
+  BOOST_CHECK_CLOSE(offsetB, 1.0, tol);
+  
+} // LineClosestPointAndOffsetsWithUnitVectorsDocumentation_test()
 
 
 // =============================================================================
@@ -178,9 +297,10 @@ BOOST_AUTO_TEST_CASE(LineClosestPointTestCase) {
   
   LineClosestPointSimple_test();
   LineClosestPointSimple45_test();
-  LineClosestPointWithLocOnLines_test();
+  LineClosestPointAndOffsets_test();
   LineClosestPointWithScaledDirs_test();
   LineClosestPointWithNonHomogeneousDirs_test();
+  LineClosestPointAndOffsetsDocumentation_test();
   
 } // BOOST_AUTO_TEST_CASE(LineClosestPointTestCase)
 
@@ -190,7 +310,8 @@ BOOST_AUTO_TEST_CASE(LineClosestPointWithUnitVectorsTestCase) {
   
   LineClosestPointWithUnitVectorsSimple_test();
   LineClosestPointWithUnitVectorsSimple45_test();
-  LineClosestPointWithUnitVectorsWithLocOnLines_test();
+  LineClosestPointWithUnitVectorsAndOffsets_test();
+  LineClosestPointAndOffsetsWithUnitVectorsDocumentation_test();
   
 } // BOOST_AUTO_TEST_CASE(LineClosestPointWithUnitVectorsTestCase)
 

--- a/test/Geometry/LineClosestPoint_test.cc
+++ b/test/Geometry/LineClosestPoint_test.cc
@@ -133,10 +133,13 @@ void LineClosestPointAndOffsetsDocumentation_test() {
    * to `2.309...`.
    * To reassign the variables after they have been defined, instead:
    * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
-   * std::tie(point, offsetA, offsetB) = geo::LineClosestPointAndOffsets(
+   * auto const xsectAndOfs = geo::LineClosestPointAndOffsets(
    *   geo::Point_t{ 0, 1, 0 }, geo::Vector_t{ 0.866, 0.0, 0.0 },
    *   geo::Point_t{ 2, 0, 1 }, geo::Vector_t{ 0.0,   0.5, 0.0 }
    *   );
+   * point = xsectAndOfs.point;
+   * offsetA = xsectAndOfs.offset1;
+   * offsetB = xsectAndOfs.offset2;
    * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    * (`point` to `geo::Point{ 2, 1, 0 }`, `offsetA` to `2.039...` and `offsetB`
    * to `2`, because the intersection point is always on the first line).
@@ -162,10 +165,13 @@ void LineClosestPointAndOffsetsDocumentation_test() {
   BOOST_TEST(offsetA   == 2.0, tol);
   BOOST_TEST(offsetB   == (2.0/0.866), tol);
   
-  std::tie(point, offsetA, offsetB) = geo::LineClosestPointAndOffsets(
+  auto const xsectAndOfs = geo::LineClosestPointAndOffsets(
     geo::Point_t{ 0, 1, 0 }, geo::Vector_t{ 0.866, 0.0, 0.0 },
     geo::Point_t{ 2, 0, 1 }, geo::Vector_t{ 0.0,   0.5, 0.0 }
     );
+  point = xsectAndOfs.point;
+  offsetA = xsectAndOfs.offset1;
+  offsetB = xsectAndOfs.offset2;
   
   BOOST_TEST(point.X() == 2.0, tol);
   BOOST_TEST(point.Y() == 1.0, tol);
@@ -249,10 +255,13 @@ void LineClosestPointAndOffsetsWithUnitVectorsDocumentation_test() {
    * to `2`.
    * To reassign the variables after they have been defined, instead:
    * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
-   * std::tie(point, offsetA, offsetB) = geo::LineClosestPointAndOffsetsWithUnitVectors(
+   * auto const xsectAndOfs = geo::LineClosestPointAndOffsetsWithUnitVectors(
    *   geo::Point_t{ 0, 1, 0 }, geo::Vector_t{ 1, 0, 0 },
    *   geo::Point_t{ 2, 0, 1 }, geo::Vector_t{ 0, 1, 0 }
    *   );
+   * point = xsectAndOfs.point;
+   * offsetA = xsectAndOfs.offset1;
+   * offsetB = xsectAndOfs.offset2;
    * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
    * (`point` to `geo::Point{ 2, 1, 0 }`, `offsetA` to `2` and `offsetB` to `1`,
    * because the intersection point is always on the first line).
@@ -278,10 +287,13 @@ void LineClosestPointAndOffsetsWithUnitVectorsDocumentation_test() {
   BOOST_TEST(offsetA   == 1.0, tol);
   BOOST_TEST(offsetB   == 2.0, tol);
   
-  std::tie(point, offsetA, offsetB) = geo::LineClosestPointAndOffsetsWithUnitVectors(
+  auto const xsectAndOfs = geo::LineClosestPointAndOffsetsWithUnitVectors(
     geo::Point_t{ 0, 1, 0 }, geo::Vector_t{ 1, 0, 0 },
     geo::Point_t{ 2, 0, 1 }, geo::Vector_t{ 0, 1, 0 }
     );
+  point = xsectAndOfs.point;
+  offsetA = xsectAndOfs.offset1;
+  offsetB = xsectAndOfs.offset2;
   
   BOOST_TEST(point.X() == 2.0, tol);
   BOOST_TEST(point.Y() == 1.0, tol);


### PR DESCRIPTION
This is the proposed resolution of [Redmine issue #25977](https://cdcvs.fnal.gov/redmine/issues/25977).

Discussion and description of the design can be found in that ticket.
As usual, the core new features are unit-tested, and all the new functions and methods are Doxygen-documented.
In particular, unit testing covers the lowest level free functions (intersection of lines) and the top level (`geo::GeometryCore` methods).

In addition, a commit is updating the Doxygen format of `geo::WireGeo`, which was somehow broken with methods escaping their documentation group.
