### PR TITLE
Fixed out-of-TPC wire intersection geometry test (issue #26127)

### DIFF
--- a/larcorealg/Geometry/GeometryCore.h
+++ b/larcorealg/Geometry/GeometryCore.h
@@ -4153,14 +4153,23 @@ namespace geo {
      * @return whether an intersection was found inside the TPC the wires belong
      * @see `geo::WiresIntersection()`, `geo::LineClosestPoint()`
      *
-     * The "intersection" refers to the projection of the wires into the same
-     * wire plane. The coordinate along the drift direction is arbitrarily set
-     * to the one of the first wire.
-     * Wires are assumed to have at most one intersection.
-     * If wires are parallel, `intersection` will have all components set to
-     * infinity (`std::numeric_limits<>::infinity()`) and `false` is returned.
-     * If the intersection is outside the TPC, `false` is also returned, but the
-     * `intersection` point will contain that intersection.
+     * The wires identified by `wid1` and `wid2` are intersected, and the
+     * 3D intersection point is written into the `intersection` parameter.
+     * The "intersection" point is actually the point belonging to the first
+     * wire (`wid2`) which is the closest (in Euclidean 3D metric) to the second
+     * wire.
+     * 
+     * The intersection is computed only if the wires belong to different planes
+     * of the same TPC. If that is not the case (i.e. they belong to different
+     * TPC or cryostat, or if they belong to the same plane), `false` is
+     * returned and `intersection` is set with all components to infinity
+     * (`std::numeric_limits<>::infinity()`).
+     * 
+     * When the intersection is computed, it is always stored in the
+     * `intersection` output parameter. Return value is `true` if this
+     * intersection lies within the physical boundaries first wire, while it is
+     * instead `false` if it lies on the extrapolation of the wire direction,
+     * but not within the wire physical extension.
      *
      * To test that the result is not infinity (nor NaN), use
      * `geo::vect::isfinite(intersection)` etc.

--- a/test/Geometry/GeometryTestAlg.cxx
+++ b/test/Geometry/GeometryTestAlg.cxx
@@ -2356,7 +2356,7 @@ namespace geo{
      */
     
     auto const isOrthogonalTo = [&wireDir](geo::Vector_t const& other)
-      { return std::abs(geo::vect::dot(wireDir, other)) < 1.0e-3; };
+      { return std::abs(geo::vect::dot(wireDir, other)) < 1.0e-5; };
     
     // we dislike well-aligned wires; and we assume that if a wire is
     // orthogonal to one of the main plane directions (dot product zero)

--- a/test/Geometry/GeometryTestAlg.cxx
+++ b/test/Geometry/GeometryTestAlg.cxx
@@ -864,27 +864,33 @@ namespace geo{
       geo::TPCGeo const& tpc = cryo.TPC(tpcid);
       decltype(auto) activeCenter = tpc.GetActiveVolumeCenter();
 
-      mf::LogVerbatim("GeometryTest")
-        << "\n\t\tTPC " << tpcid
-          << " " << geom->GetLArTPCVolumeName(tpcid)
-          << " has " << tpc.Nplanes() << " planes."
-        << "\n\t\tTPC location: ( "
-          << tpc.MinX() << " ; " << tpc.MinY() << " ; "<< tpc.MinZ()
-          << " ) =>  ( "
-          << tpc.MaxX() << " ; " << tpc.MaxY() << " ; "<< tpc.MaxZ()
-          << " ) [cm]"
-        << "\n\t\tTPC Dimensions (W x H x L, cm): "
-          << tpc.Width() << " (" << directionName(tpc.WidthDir()) << ")"
-          << " x " << tpc.Height() << " (" << directionName(tpc.HeightDir()) << ")"
-          << " x " << tpc.Length() << " (" << directionName(tpc.LengthDir()) << ")"
-        << "\n\t\tTPC Active Dimensions: "
-          << 2.*tpc.ActiveHalfWidth() << " x " << 2.*tpc.ActiveHalfHeight() << " x " << tpc.ActiveLength()
-          << " around ( " << activeCenter.X() << " ; " << activeCenter.Y()
-          << " ; "<< activeCenter.Z() << " ) cm"
-        << "\n\t\tTPC mass: " << tpc.ActiveMass()
-        << "\n\t\tTPC drift distance: " << tpc.DriftDistance()
-          << ", direction: " << tpc.DriftDir();
-
+      {
+        mf::LogVerbatim log { "GeometryTest" };
+        log
+          << "\n\t\tTPC " << tpcid
+            << " " << geom->GetLArTPCVolumeName(tpcid)
+            << " has " << tpc.Nplanes() << " planes."
+          << "\n\t\tTPC location: ( "
+            << tpc.MinX() << " ; " << tpc.MinY() << " ; "<< tpc.MinZ()
+            << " ) =>  ( "
+            << tpc.MaxX() << " ; " << tpc.MaxY() << " ; "<< tpc.MaxZ()
+            << " ) [cm]"
+          << "\n\t\tTPC Dimensions (W x H x L, cm): "
+            << tpc.Width() << " (" << directionName(tpc.WidthDir()) << ")"
+            << " x " << tpc.Height() << " (" << directionName(tpc.HeightDir()) << ")"
+            << " x " << tpc.Length() << " (" << directionName(tpc.LengthDir()) << ")"
+          << "\n\t\tTPC Active Dimensions: "
+            << 2.*tpc.ActiveHalfWidth() << " x " << 2.*tpc.ActiveHalfHeight() << " x " << tpc.ActiveLength()
+            << " around ( " << activeCenter.X() << " ; " << activeCenter.Y()
+            << " ; "<< activeCenter.Z() << " ) cm"
+          ;
+        if (fComputeMass)
+          log << "\n\t\tTPC mass: " << tpc.ActiveMass();
+        log
+          << "\n\t\tTPC drift distance: " << tpc.DriftDistance()
+            << ", direction: " << tpc.DriftDir();
+      }
+      
       for(size_t p = 0; p < tpc.Nplanes(); ++p) {
         geo::PlaneGeo const& plane = tpc.Plane(p);
 

--- a/test/Geometry/GeometryTestAlg.cxx
+++ b/test/Geometry/GeometryTestAlg.cxx
@@ -2355,12 +2355,11 @@ namespace geo{
       { return std::abs(geo::vect::dot(wireDir, other)) < 1.0e-5; };
     
     // we dislike wires aligned to plane frame:
-    if (isOrthogonalTo(plane.WidthDir<geo::Vector_t>())) // || to `DepthDir()`?
+    if (isOrthogonalTo(plane.WidthDir<geo::Vector_t>()))
       return true;
-    if (isOrthogonalTo(plane.DepthDir<geo::Vector_t>())) // || to `WidthDir()`?
+    if (isOrthogonalTo(plane.DepthDir<geo::Vector_t>()))
       return true;
     
-    // || to `GetWireDirection()`?
     if (isOrthogonalTo(plane.GetIncreasingWireDirection<geo::Vector_t>()))
       return true;
     

--- a/test/Geometry/GeometryTestAlg.h
+++ b/test/Geometry/GeometryTestAlg.h
@@ -13,6 +13,7 @@
 
 // LArSoft includes
 #include "larcorealg/TestUtils/NameSelector.h"
+#include "larcoreobj/SimpleTypesAndConstants/geo_vectors.h"
 
 // ROOT
 #include "TVector3.h"
@@ -33,6 +34,7 @@ namespace geo {
 
   // forward declarations
   class GeometryCore;
+  class CryostatGeo;
   class TPCGeo;
   class PlaneGeo;
   class AuxDetGeo;
@@ -220,6 +222,10 @@ namespace geo {
     bool CheckAuxDetSensitiveAtPosition
       (double const pos[3], unsigned int expectedDet, unsigned int expectedSens)
       const;
+
+    /// Helper function for `testWireIntersection()`.
+    unsigned int planeAlignmentTo
+      (geo::PlaneGeo const& plane, geo::Vector_t const& wireDir) const;
 
     /// Performs the wire intersection test at a single point
     unsigned int testWireIntersectionAt

--- a/test/Geometry/GeometryTestAlg.h
+++ b/test/Geometry/GeometryTestAlg.h
@@ -224,7 +224,7 @@ namespace geo {
       const;
 
     /// Helper function for `testWireIntersection()`.
-    unsigned int planeAlignmentTo
+    bool isWireAlignedToPlaneDirections
       (geo::PlaneGeo const& plane, geo::Vector_t const& wireDir) const;
 
     /// Performs the wire intersection test at a single point


### PR DESCRIPTION
This is the proposed resolution for [Redmine issue #26127](https://cdcvs.fnal.gov/redmine/issues/26127).

As @marcodeltutto has described, a part of the wire intersection test is supposed to pick two wires from different TPC, that are not parallel, and return that the intersection is not possible (or something like that) because belonging on different TPC.
The code picking the wire was quite lazy and relied on a situation that SBND does not fall into any more.
This pull request should rectify that.

It also contains minor changes that I made while working on the resolution.
Another commit attempts to clarify the language of `geo::GeometryCore::WireIDsIntersect()` documentation explaining the domain of the method and its possible return values.

Testing was performed **only on `sbndcode` branch** where the issue showed up (with a geometry different from the "more compliant" one in `develop`). I rely on integration tests to complete the testing.