### PR TITLE
Bug fix from v10 geometry update

### DIFF
--- a/larcorealg/Geometry/TPCGeo.cxx
+++ b/larcorealg/Geometry/TPCGeo.cxx
@@ -82,9 +82,10 @@ namespace geo {
     fActiveHalfHeight = active_volume_box->GetDY();
     fActiveLength = 2.0 * active_volume_box->GetDZ();
 
-    fHalfWidth = active_volume_box->GetDX();
-    fHalfHeight = active_volume_box->GetDY();
-    fLength = 2.0 * active_volume_box->GetDZ();
+    auto const* total_volume_box = static_cast<TGeoBBox const*>(fTotalVolume->GetShape());
+    fHalfWidth = total_volume_box->GetDX();
+    fHalfHeight = total_volume_box->GetDY();
+    fLength = 2.0 * total_volume_box->GetDZ();
 
     // Check that the rotation matrix to the world is the identity, if not we need to
     // change the width, height and length values; the correspondence of these to x, y and
@@ -94,7 +95,6 @@ namespace geo {
     // TODO: there must be a more general way to do this...
     double Rxx, Rxy, Rxz, Ryx, Ryy, Ryz, Rzx, Rzy, Rzz;
     fTrans.Matrix().Rotation().GetComponents(Rxx, Rxy, Rxz, Ryx, Ryy, Ryz, Rzx, Rzy, Rzz);
-    auto const* total_volume_box = static_cast<TGeoBBox const*>(fTotalVolume->GetShape());
     if (Rxx != 1) {
       if (std::abs(Rxz) == 1) {
         fActiveHalfWidth = active_volume_box->GetDZ();

--- a/larcorealg/Geometry/WireReadoutGeom.h
+++ b/larcorealg/Geometry/WireReadoutGeom.h
@@ -335,7 +335,6 @@ namespace geo {
      * @brief Computes the intersection between two wires.
      * @param wid1 ID of the first wire
      * @param wid2 ID of the other wire
-     * @param widIntersect (output) the coordinate of the intersection point
      * @return whether an intersection was found within the TPC
      *
      * The "intersection" refers to the projection of the wires into the same @f$ x = 0


### PR DESCRIPTION
TPC dimensions are reported in v10 in a way different than it was before.
They mix active and "box" dimensions.

This pull request is expected to restore the old behaviour, with `Width()`, `Height()`, `Length()` and their sweet halves reporting the size of the (close-to-useless) TPC box, while the `Active` counterparts stick to the (useful) active volume.

A conclusion on this PR is critical for SBN.


I slipped one of the many documentation fixes needed after v10 changes, just because I had it at hand.