### PR TITLE
Restoring the full geometry dump capability.

### DIFF
--- a/larcorealg/Geometry/CMakeLists.txt
+++ b/larcorealg/Geometry/CMakeLists.txt
@@ -131,6 +131,7 @@ cet_make_library(SOURCE
   StandaloneGeometrySetup.cxx
   TPCGeo.cxx
   WireGeo.cxx
+  WireReadoutDumper.cxx
   WireReadoutGeom.cxx
   WireReadoutGeomBuilderStandard.cxx
   WireReadoutSorterStandard.cxx

--- a/larcorealg/Geometry/TPCGeo.h
+++ b/larcorealg/Geometry/TPCGeo.h
@@ -284,6 +284,11 @@ void geo::TPCGeo::PrintTPCInfo(Stream&& out,
 
   if (verbosity-- <= 0) return; // 1
 
+  //----------------------------------------------------------------------------
+  out << "\n"
+      << indent << "drift direction " << DriftDir() << " from cathode around " << GetCathodeCenter()
+      << " through " << DriftDistance() << " cm";
+
   if (verbosity-- <= 0) return; // 2
 
   if (verbosity-- <= 0) return; // 3

--- a/larcorealg/Geometry/WireReadoutDumper.cxx
+++ b/larcorealg/Geometry/WireReadoutDumper.cxx
@@ -1,0 +1,194 @@
+/**
+ * @file    larcorealg/Geometry/WireReadoutDumper.cxx
+ * @brief   Algorithm dumping the full detector geometry down to wires.
+ * @author  Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date    January 31, 2025
+ * @file    larcorealg/Geometry/WireReadoutDumper.h
+ */
+
+// library header
+#include "larcorealg/Geometry/WireReadoutDumper.h"
+
+// LArSoft libraries
+#include "larcorealg/CoreUtils/counter.h"
+#include "larcorealg/Geometry/BoxBoundedGeo.h"
+#include "larcorealg/Geometry/CryostatGeo.h"
+#include "larcorealg/Geometry/OpDetGeo.h"
+#include "larcorealg/Geometry/PlaneGeo.h"
+#include "larcorealg/Geometry/TPCGeo.h"
+
+// C++ libraries
+#include <ostream>
+
+// -----------------------------------------------------------------------------
+geo::WireReadoutDumper::WireReadoutDumper(geo::GeometryCore const* geom,
+                                          geo::WireReadoutGeom const* wireGeom,
+                                          geo::AuxDetGeometryCore const* auxGeom)
+  : fGeom{geom}, fWireGeom{wireGeom}, fAuxGeom{auxGeom}
+{}
+
+// -----------------------------------------------------------------------------
+void geo::WireReadoutDumper::dump(std::ostream& out,
+                                  std::string const& indent,
+                                  std::string const& firstIndent) const
+{
+
+  dumpDetectorInfo(out, indent, firstIndent);
+
+  if (fGeom) {
+    for (auto const& cryostat : fGeom->Iterate<geo::CryostatGeo>()) {
+      out << "\n";
+      dumpCryostat(out, cryostat, indent + "    ", indent + "  ");
+    }
+  }
+
+  if (fAuxGeom) {
+    out << "\n";
+    dumpAuxiliaryDetectors(out, indent, indent);
+  }
+
+  out << '\n';
+
+} // geo::WireReadoutDumper::dump()
+
+// -----------------------------------------------------------------------------
+geo::WireReadoutDumper::StreamAdapter geo::WireReadoutDumper::toStream(
+  std::string indent,
+  std::string firstIndent) const
+{
+  return {this, std::move(indent), std::move(firstIndent)};
+}
+
+// -----------------------------------------------------------------------------
+void geo::WireReadoutDumper::dumpDetectorInfo(std::ostream& out,
+                                              std::string const& indent,
+                                              std::string const& firstIndent) const
+{
+
+  out << firstIndent << "Detector " << (fGeom ? fGeom->DetectorName() : "") << " has "
+      << (fGeom ? std::to_string(fGeom->Ncryostats()) : "unknown") << " cryostats and "
+      << (fAuxGeom ? std::to_string(fAuxGeom->NAuxDets()) : "unknown") << " auxiliary detectors:";
+
+  if (fGeom) {
+    geo::BoxBoundedGeo const& box = fGeom->DetectorEnclosureBox();
+
+    out << "\n"
+        << indent << "  Detector enclosure: " << box.Min() << " -- " << box.Max() << " cm => ( "
+        << box.SizeX() << " x " << box.SizeY() << " x " << box.SizeZ() << " ) cm^3";
+  }
+
+} // geo::WireReadoutDumper::dumpDetectorInfo()
+
+// -----------------------------------------------------------------------------
+void geo::WireReadoutDumper::dumpCryostat(std::ostream& out,
+                                          geo::CryostatGeo const& cryostat,
+                                          std::string const& indent,
+                                          std::string const& firstIndent) const
+{
+
+  // the indentation game:
+  //   `PrintXxxxInfo()` methods don't indent the first line;
+  //   our `dumpCryostat()` do as directed, but don't start with a new line
+
+  out << firstIndent;
+  cryostat.PrintCryostatInfo(out, indent, cryostat.MaxVerbosity);
+
+  //
+  // TPC
+  //
+  for (geo::TPCGeo const& tpc : cryostat.IterateTPCs()) {
+
+    out << "\n" << indent;
+    tpc.PrintTPCInfo(out, indent + "  ", tpc.MaxVerbosity);
+
+    // for (unsigned int const planeNo: tpc.Nplanes()) {
+    //   geo::PlaneGeo const& plane = fWireGeom->Plane({ tpc.ID(), planeNo });
+
+    for (auto const& plane : fWireGeom->Iterate<geo::PlaneGeo>(tpc.ID())) {
+      out << "\n";
+      dumpTPCplane(out, plane, indent + "    ", indent + "  ");
+
+    } // for plane
+  }   // for TPC
+
+  //
+  // optical detectors
+  //
+  for (unsigned int const iOpDet : util::counter(cryostat.NOpDet())) {
+    geo::OpDetGeo const& opDet = cryostat.OpDet(iOpDet);
+    out << "\n" << indent << "  [OpDet #" << iOpDet << "] ";
+    opDet.PrintOpDetInfo(out, indent + "    ", opDet.MaxVerbosity);
+  } // for
+
+} // geo::WireReadoutDumper::dumpCryostat()
+
+// -----------------------------------------------------------------------------
+void geo::WireReadoutDumper::dumpTPCplane(std::ostream& out,
+                                          geo::PlaneGeo const& plane,
+                                          std::string const& indent,
+                                          std::string const& firstIndent) const
+{
+
+  const unsigned int nWires = plane.Nwires();
+
+  out << firstIndent;
+  plane.PrintPlaneInfo(out, indent, plane.MaxVerbosity);
+  SigType_t const sigType = fWireGeom->SignalType(plane.ID());
+  out << "\n"
+      << indent << "signal type: " << SignalTypeName(sigType) << " (" << static_cast<int>(sigType)
+      << ")";
+
+  for (unsigned int const wireNo : util::counter(nWires)) {
+    geo::WireID const wireID{plane.ID(), wireNo};
+    geo::WireGeo const& wire = plane.Wire(wireID);
+    out << "\n" << indent << wireID << " ";
+    wire.PrintWireInfo(out, indent, wire.MaxVerbosity);
+  } // for wire
+
+} // geo::WireReadoutDumper::dumpTPCplane()
+
+// -----------------------------------------------------------------------------
+void geo::WireReadoutDumper::dumpAuxiliaryDetectors(std::ostream& out,
+                                                    std::string const& indent,
+                                                    std::string const& firstIndent) const
+{
+
+  unsigned int const nAuxDets = fAuxGeom->NAuxDets();
+  out << firstIndent << "Auxiliary detectors (" << nAuxDets << "):";
+  for (unsigned int const iDet : util::counter(nAuxDets)) {
+    geo::AuxDetGeo const& auxDet = fAuxGeom->AuxDet(iDet);
+
+    out << '\n' << indent << "[#" << iDet << "] ";
+    auxDet.PrintAuxDetInfo(out, indent + "  ", auxDet.MaxVerbosity);
+
+    unsigned int const nSensitive = auxDet.NSensitiveVolume();
+    switch (nSensitive) {
+    case 0: break;
+    case 1: {
+      AuxDetSensitiveGeo const& auxDetS = auxDet.SensitiveVolume(0U);
+      out << "\n" << indent << "  ";
+      auxDetS.PrintAuxDetInfo(out, indent + "    ", auxDetS.MaxVerbosity);
+      break;
+    }
+    default:
+      for (unsigned int const iSens : util::counter(nSensitive)) {
+        out << "\n" << indent << "  [#" << iSens << "] ";
+        AuxDetSensitiveGeo const& auxDetS = auxDet.SensitiveVolume(iSens);
+        auxDetS.PrintAuxDetInfo(out, indent + "    ", auxDetS.MaxVerbosity);
+      } // for
+      break;
+    } // if sensitive detectors
+
+  } // for auxiliary detector
+
+} // geo::WireReadoutDumper::dumpAuxiliaryDetectors()
+
+// -----------------------------------------------------------------------------
+std::ostream& geo::operator<<(std::ostream& out,
+                              geo::WireReadoutDumper::StreamAdapter const& dumpAdapter)
+{
+  dumpAdapter.dumper->dump(out, dumpAdapter.indent, dumpAdapter.firstIndent);
+  return out;
+}
+
+// -----------------------------------------------------------------------------

--- a/larcorealg/Geometry/WireReadoutDumper.h
+++ b/larcorealg/Geometry/WireReadoutDumper.h
@@ -1,0 +1,183 @@
+/**
+ * @file    larcorealg/Geometry/WireReadoutDumper.h
+ * @brief   Algorithm dumping the full detector geometry down to wires.
+ * @author  Gianluca Petrillo (petrillo@slac.stanford.edu)
+ * @date    January 31, 2025
+ * @file    larcorealg/Geometry/WireReadoutDumper.cxx
+ */
+
+#ifndef LARCOREALG_GEOMETRY_WIREREADOUTDUMPER_H
+#define LARCOREALG_GEOMETRY_WIREREADOUTDUMPER_H
+
+// LArSoft libraries
+#include "larcorealg/Geometry/AuxDetGeometryCore.h"
+#include "larcorealg/Geometry/GeometryCore.h"
+#include "larcorealg/Geometry/WireReadoutGeom.h"
+
+// C++ libraries
+#include <iosfwd> // std::ostream
+#include <string>
+#include <utility> // std::move()
+
+// -----------------------------------------------------------------------------
+namespace geo {
+  class WireReadoutDumper;
+}
+/**
+ * @brief Algorithm dumping the full detector geometry down to wires.
+ *
+ * This algorithm dumps all the available information from the geometry,
+ * including the chamber information (from `geo::GeometryCore`), the wire and
+ * readout information (from `geo::WireReadoutGeom`) and the auxiliary detectors
+ * (from `geo::AuxDetGeometryCore`).
+ * Any of the service providers can be omitted (`nullptr`), in which case the
+ * relative information will not be printed.
+ *
+ * A typical usage example is to create the algorithm and then call its `dump()`
+ * method, like in:
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+ * auto const* geom = lar::providerFrom<geo::Geometry>();
+ * auto const* wireGeom = &(art::ServiceHandle<geo::WireReadout>()->Get());
+ * auto const* auxDetGeom = art::ServiceHandle<geo::AuxDetGeometry>()->GetProviderPtr();
+ * geo::WireReadoutDumper const dumper{ geom, wireGeom, auxDetGeom };
+ * dumper.dump(std::cout);
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ *
+ * The interface supports only dumping to C++ output streams (including
+ * `std::ostringstream` to bridge to libraries which can us strings).
+ * However, for streams which support inserter operators to `std::ostream`,
+ * the following is also possible:
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+ * mf::LogInfo{ "DumpGeometry" } << dumper.toStream();
+ * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ * The messagefacility library streams (like in this example) fall into this
+ * category.
+ *
+ * The output is documented in the `dump()` method.
+ *
+ */
+class geo::WireReadoutDumper {
+
+  /// Cached geometry service provider.
+  geo::GeometryCore const* fGeom = nullptr;
+
+  /// Cached wire readout service provider.
+  geo::WireReadoutGeom const* fWireGeom = nullptr;
+
+  /// Cached auxiliary detector geometry service provider.
+  geo::AuxDetGeometryCore const* fAuxGeom = nullptr;
+
+  /// Helper for insertion into C++ output streams.
+  struct StreamAdapter {
+    WireReadoutDumper const* dumper;
+    std::string indent;
+    std::string firstIndent;
+  };
+
+  friend std::ostream& operator<<(std::ostream& out, StreamAdapter const& dumpAdapter);
+
+public:
+  /// Constructor: acquires geometry service providers.
+  WireReadoutDumper(geo::GeometryCore const* geom,
+                    geo::WireReadoutGeom const* wireGeom,
+                    geo::AuxDetGeometryCore const* auxGeom);
+
+  /**
+   * @brief Dumps the full geometry information into a stream.
+   * @param out the stream to write the information in
+   * @param indent string to be prepended to each output line except the first
+   * @param firstIndent string to be prepended to the first line only
+   *
+   * The output is in human-readable format, structured as follows:
+   *  * all the information for each cryostat, including:
+   *     * all the information for each TPC, including:
+   *         * all the information for each readout plane, including:
+   *             * all the information for each sensitive element (e.g. wire)
+   *     * all the optical detector information
+   *  * all information for the "auxiliary" detectors (typically, scintillators
+   *    for cosmic ray tagging), including:
+   *     * all the information for the "sensitive detectors" in each module.
+   *
+   * The output starts on the current line of the stream and it ends with a new
+   * line.
+   *
+   */
+  void dump(std::ostream& out, std::string const& indent, std::string const& firstIndent) const;
+
+  /**
+   * @brief Dumps the full geometry information into a stream.
+   * @param out the stream to write the information in
+   * @param indent (default: none) string to be prepended to all output lines
+   * @see `dump(std::ostream&, std::string const&, std::string const&) const`
+   *
+   * Dumps the geometry like
+   * `dump(std::ostream&, std::string const&, std::string const&) const` does,
+   * but using the same indentation string for all lines.
+   */
+  void dump(std::ostream& out, std::string const& indent = "") const { dump(out, indent, indent); }
+
+  /**
+   * @brief Adapter to send the dump to a C++ output stream via insertion.
+   * @param indent (default: none) string to be prepended to all output lines
+   * @param firstIndent string to be prepended to the first line only
+   * @return an opaque adapter for insertion into a C++ output stream
+   * @see `dump()`
+   *
+   * Example: after a `geo::WireReadoutDumper dumper` has been initialized,
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+   * std::cout << dumper.toStream("> ");
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * will dump the full geometry into `std::cout`.
+   *
+   */
+  StreamAdapter toStream(std::string indent, std::string firstIndent) const;
+
+  /**
+   * @brief Adapter to send the dump to a C++ output stream via insertion.
+   * @param indent (default: none) string to be prepended to all output lines
+   * @return an opaque adapter for insertion into a C++ output stream
+   * @see `dump()`
+   *
+   * Example: after a `geo::WireReadoutDumper dumper` has been initialized,
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~{.cpp}
+   * std::cout << dumper.toStream("> ");
+   * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+   * will dump the full geometry into `std::cout`.
+   *
+   */
+  auto toStream(std::string indent = "") const { return toStream(indent, std::move(indent)); }
+
+private:
+  /// Dumps the general detector information.
+  void dumpDetectorInfo(std::ostream& out,
+                        std::string const& indent,
+                        std::string const& firstIndent) const;
+
+  /// Dumps all content of the specified `cryostat`.
+  void dumpCryostat(std::ostream& out,
+                    geo::CryostatGeo const& cryostat,
+                    std::string const& indent,
+                    std::string const& firstIndent) const;
+
+  /// Dumps the information from the specified `plane` (including wires).
+  void dumpTPCplane(std::ostream& out,
+                    geo::PlaneGeo const& plane,
+                    std::string const& indent,
+                    std::string const& firstIndent) const;
+
+  /// Dumps all auxiliary detector information.
+  void dumpAuxiliaryDetectors(std::ostream& out,
+                              std::string const& indent,
+                              std::string const& firstIndent) const;
+
+}; // geo::WireReadoutDumper
+
+// -----------------------------------------------------------------------------
+namespace geo {
+  /// Helper for `geo::WireReadoutDumper::toStream()`.
+  std::ostream& operator<<(std::ostream& out, WireReadoutDumper::StreamAdapter const& dumpAdapter);
+}
+
+// -----------------------------------------------------------------------------
+
+#endif // LARCOREALG_GEOMETRY_WIREREADOUTDUMPER_H


### PR DESCRIPTION
LArSoft v10 crippled the geometry dumping capability, which used to be as simple as calling `GeometryCore::Print()`. While that call is still available, `GeometryCore` is aware of only part of the geometry of the detector, and can only report that part.

This PR aims to restore the functionality of the full geometry dump.

There is going to be a related LArSoft/larcore pull request hooking the existing dumping module to this algorithm.

Note that this invaluable tool is often used both for information and for diagnosis (for example, it allowed ICARUS to discovers bugs in the v10 geometry migration). Common questions are "which are the TPC coordinates", "where are the planes", and "which orientation do wires have", by analysers who hard-code the numbers in analysis scripts.
However, differently from #39, this PR is not in the critical path for SBN.

This PR was tested on `icaruscode` "v10" geometry and the updated dumping module.


Design
-------

Because there is now no single service knowing the full geometry, the dumping is delegated to a dedicated _art_-independent algorithm in `larcorealg`, which relies on the relevant service providers (geometry, readout and auxiliary).
The dumping is directed by the algorithm, which follows the structure of the geometry and delegates the dumping of the individual elements to the elements themselves.
The algorithm should also support partial dumping when some services are not provided, but that was not tested.

A small part of the information that used to be dumped is not available any more, and there is no attempt in this PR to recreate it. Instead, a couple of TPC facts got dropped but are still available, and this is restored in the TPC dump.


