### PR TITLE
Use Raw Pointer in SetupAuxDetGeometry Constructor for AuxDetInitializer Argument

### DIFF
--- a/larcorealg/Geometry/StandaloneGeometrySetup.h
+++ b/larcorealg/Geometry/StandaloneGeometrySetup.h
@@ -95,7 +95,7 @@ namespace lar::standalone {
   std::unique_ptr<geo::AuxDetGeometryCore> AuxDetGeometryFor(
     fhicl::ParameterSet const& pset,
     std::unique_ptr<geo::AuxDetGeoObjectSorter> sorter,
-    std::unique_ptr<geo::AuxDetInitializer> initializer);
+    std::unique_ptr<geo::AuxDetInitializer> initializer = nullptr);
 
   namespace detail {
     template <typename T>
@@ -117,13 +117,11 @@ namespace lar::standalone {
 
   template <typename ObjectSorter = geo::AuxDetGeoObjectSorterStandard>
   std::unique_ptr<geo::AuxDetGeometryCore> SetupAuxDetGeometry(
-    fhicl::ParameterSet const& pset,
-    geo::AuxDetInitializer* initializer = nullptr)
+    fhicl::ParameterSet const& pset)
   {
     auto sorting_parameters = pset.get<fhicl::ParameterSet>("SortingParameters", {});
     return AuxDetGeometryFor(pset,
-                             detail::make_unique_maybe_default<ObjectSorter>(sorting_parameters),
-                             std::move(std::unique_ptr<geo::AuxDetInitializer>(initializer)));
+                             detail::make_unique_maybe_default<ObjectSorter>(sorting_parameters));
   }
 
   template <typename ObjectSorter = geo::WireReadoutSorterStandard,

--- a/larcorealg/Geometry/StandaloneGeometrySetup.h
+++ b/larcorealg/Geometry/StandaloneGeometrySetup.h
@@ -118,12 +118,12 @@ namespace lar::standalone {
   template <typename ObjectSorter = geo::AuxDetGeoObjectSorterStandard>
   std::unique_ptr<geo::AuxDetGeometryCore> SetupAuxDetGeometry(
     fhicl::ParameterSet const& pset,
-    std::unique_ptr<geo::AuxDetInitializer> initializer = nullptr)
+    geo::AuxDetInitializer* initializer = nullptr)
   {
     auto sorting_parameters = pset.get<fhicl::ParameterSet>("SortingParameters", {});
     return AuxDetGeometryFor(pset,
                              detail::make_unique_maybe_default<ObjectSorter>(sorting_parameters),
-                             std::move(initializer));
+                             std::move(std::unique_ptr<geo::AuxDetInitializer>(initializer)));
   }
 
   template <typename ObjectSorter = geo::WireReadoutSorterStandard,

--- a/larcorealg/Geometry/StandaloneGeometrySetup.h
+++ b/larcorealg/Geometry/StandaloneGeometrySetup.h
@@ -116,8 +116,7 @@ namespace lar::standalone {
   }
 
   template <typename ObjectSorter = geo::AuxDetGeoObjectSorterStandard>
-  std::unique_ptr<geo::AuxDetGeometryCore> SetupAuxDetGeometry(
-    fhicl::ParameterSet const& pset)
+  std::unique_ptr<geo::AuxDetGeometryCore> SetupAuxDetGeometry(fhicl::ParameterSet const& pset)
   {
     auto sorting_parameters = pset.get<fhicl::ParameterSet>("SortingParameters", {});
     return AuxDetGeometryFor(pset,


### PR DESCRIPTION
In SBN, we have [Python code](https://github.com/SBNSoftware/sbndcode/blob/feature/mdeltutt_python_services/sbndcode/gallery/python/LArSoftUtils.py#L202) that allow us to call some of the LArSoft's services from Python. We are working on updating this Python code to work with LArSoft v10. We are able to call most of the services, but have been failing to call `SetupAuxDetGeometry` from Python. The reason boils down to the following:  `SetupAuxDetGeometry` expects a `unique_ptr` as an argument, but I was not able to find a way for cppyy to correclty interpret that and succesfully pass that argument.

With this PR I propose to use a raw pointer instead. I have tested it within Python and confirm it works.
