### PR TITLE
Feature/calcuttj remove rangev3

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,10 +16,22 @@ project(larcorealg VERSION 10.00.04 LANGUAGES CXX)
 include(CetCMakeEnv)
 cet_cmake_env()
 
+# Force C++20. LArSoft v10_21_01 / e26 defaults to C++17 (CETPKG_CXX_STANDARD=17,
+# buildtool passes -DCMAKE_CXX_STANDARD=17), but the range-v3 removal in
+# Geometry/Iterable.h uses std::ranges, which is only available in C++20.
+# cetmodules delegates the standard to CMAKE_CXX_STANDARD (cet_set_compiler_flags
+# has no CXX_STANDARD option); this normal variable overrides the cache value.
+set(CMAKE_CXX_STANDARD 20)
+set(CMAKE_CXX_STANDARD_REQUIRED ON)
+
 cet_set_compiler_flags(DIAGS CAUTIOUS
   WERROR
   NO_UNDEFINED
-  EXTRA_FLAGS -pedantic -Wno-unused-local-typedefs
+  # -Wno-error=cpp: the cvmfs ROOT (v6_28_12) is built for C++17 and its headers
+  # emit a #warning when consumed under a different standard; WERROR would turn
+  # that into an error. (Diagnostic only -- C++20 code against a C++17 ROOT is not
+  # a supported configuration.)
+  EXTRA_FLAGS -pedantic -Wno-unused-local-typedefs -Wno-error=cpp
 )
 
 cet_report_compiler_flags(REPORT_THRESHOLD VERBOSE)

--- a/larcorealg/CoreUtils/CMakeLists.txt
+++ b/larcorealg/CoreUtils/CMakeLists.txt
@@ -5,7 +5,6 @@ cet_make_library(SOURCE
   SearchPathPlusRelative.cxx
   SortByPointers.h
   LIBRARIES PUBLIC
-  range-v3::range-v3
   cetlib_except::cetlib_except
   PRIVATE
   cetlib::cetlib

--- a/larcorealg/CoreUtils/counter.h
+++ b/larcorealg/CoreUtils/counter.h
@@ -11,7 +11,7 @@
 #define LARCOREALG_COREUTILS_COUNTER_H
 
 // External libraries
-#include "range/v3/view.hpp"
+#include <ranges>
 
 // C/C++ libraries
 #include <cstddef> // std::size_t
@@ -291,14 +291,14 @@ namespace util::details {
 template <typename T>
 auto util::counter(T begin, T end)
 {
-  return ranges::make_subrange(count_iterator(begin), count_iterator(end));
+  return std::ranges::subrange(count_iterator(begin), count_iterator(end));
 }
 
 //------------------------------------------------------------------------------
 template <typename T>
 auto util::infinite_counter(T begin)
 {
-  return ranges::make_subrange(count_iterator(begin), details::infinite_endcount_iterator<T>());
+  return std::ranges::subrange(count_iterator(begin), details::infinite_endcount_iterator<T>());
 }
 
 //------------------------------------------------------------------------------

--- a/larcorealg/CoreUtils/makeValueIndex.h
+++ b/larcorealg/CoreUtils/makeValueIndex.h
@@ -18,7 +18,7 @@
 #include "larcorealg/CoreUtils/fromFutureImport.h" // util::pre_std::identity<>
 
 // External libraries
-#include "range/v3/view/enumerate.hpp"
+#include "larcorealg/CoreUtils/enumerate.h"
 
 // C/C++ standard library
 #include <cstddef> // std::size_t
@@ -80,7 +80,7 @@ decltype(auto) util::makeValueIndex(Coll const& coll, Extractor getter)
   using Map_t = std::map<Key_t, std::size_t>;
 
   Map_t index;
-  for (auto&& [iValue, collValue] : coll | ranges::views::enumerate) {
+  for (auto&& [iValue, collValue] : util::enumerate(coll)) {
 
     Key_t const& key = getter(collValue);
     auto const iKey = index.lower_bound(key);

--- a/larcorealg/Geometry/CMakeLists.txt
+++ b/larcorealg/Geometry/CMakeLists.txt
@@ -158,7 +158,6 @@ cet_make_library(SOURCE
   cetlib_except::cetlib_except
   CLHEP::Geometry
   CLHEP::Vector
-  range-v3::range-v3
   ROOT::Core
   ROOT::GenVector
   ROOT::Geom

--- a/larcorealg/Geometry/Iterable.h
+++ b/larcorealg/Geometry/Iterable.h
@@ -8,7 +8,7 @@
 #include "larcoreobj/SimpleTypesAndConstants/geo_types.h"
 
 // External libraries
-#include "range/v3/view.hpp"
+#include <ranges>
 
 // C/C++ standard libraries
 #include <type_traits>
@@ -49,7 +49,7 @@ namespace geo {
     };
 
     template <typename Begin, typename End>
-    using RangeType = decltype(ranges::make_subrange(std::declval<Begin>(), std::declval<End>()));
+    using RangeType = decltype(std::ranges::subrange(std::declval<Begin>(), std::declval<End>()));
   }
 
   template <typename IterationPolicy, typename Transform = void_tag>
@@ -120,13 +120,13 @@ namespace geo {
     template <typename T>
     range_type<T> Iterate() const
     {
-      return ranges::make_subrange(begin<T>(), end<T>());
+      return std::ranges::subrange(begin<T>(), end<T>());
     }
 
     template <typename T, typename ID>
     range_type<T> Iterate(ID const& id) const
     {
-      return ranges::make_subrange(begin<T>(id), end<T>(id));
+      return std::ranges::subrange(begin<T>(id), end<T>(id));
     }
 
   private:

--- a/test/CoreUtils/MetaUtils_test.cc
+++ b/test/CoreUtils/MetaUtils_test.cc
@@ -14,7 +14,7 @@
 #include "larcorealg/CoreUtils/MetaUtils.h"
 
 // External libraries
-#include "range/v3/view/zip.hpp"
+#include "larcorealg/CoreUtils/zip.h"
 
 // C/C++ standard libraries
 #include <array>
@@ -327,7 +327,7 @@ void referenced_addresser_documentation_test()
     data.cbegin(), data.cend(), std::back_inserter(dataPtr), util::reference_addresser());
 
   // test
-  for (auto&& [data, dataPtr] : ranges::views::zip(data, dataPtr)) {
+  for (auto&& [data, dataPtr] : util::zip(data, dataPtr)) {
     BOOST_TEST(dataPtr == &data);
   }
 }

--- a/test/CoreUtils/get_elements_test.cc
+++ b/test/CoreUtils/get_elements_test.cc
@@ -13,7 +13,7 @@
 #include <boost/test/unit_test.hpp>
 
 // External libraries
-#include "range/v3/view/zip.hpp"
+#include "larcorealg/CoreUtils/zip.h"
 
 // C/C++ libraries
 #include <cstddef> // std::size_t
@@ -215,7 +215,7 @@ void get_elements_documentation_test()
   std::vector<int> const expected_exponents{0, 1, 2};
 
   BOOST_TEST(factors.size() == expected_factors.size());
-  for (auto const& [f, expected_f] : ranges::views::zip(factors, expected_factors)) {
+  for (auto const& [f, expected_f] : util::zip(factors, expected_factors)) {
     BOOST_TEST(f.first == expected_f.first);
     BOOST_TEST(f.second == expected_f.second);
   }

--- a/test/CoreUtils/operations_test.cc
+++ b/test/CoreUtils/operations_test.cc
@@ -15,7 +15,7 @@
 #include "larcorealg/CoreUtils/operations.h"
 
 // External libraries
-#include "range/v3/view/zip.hpp"
+#include "larcorealg/CoreUtils/zip.h"
 
 // C/C++ standard libraries
 #include <algorithm>
@@ -44,7 +44,7 @@ void test_AddressTaker_documentation()
   // - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
   // the test
   BOOST_TEST(ptrs.size() == data.size());
-  for (auto&& [value, ptr] : ranges::views::zip(data, ptrs)) {
+  for (auto&& [value, ptr] : util::zip(data, ptrs)) {
     BOOST_TEST(ptr);
     BOOST_TEST(*ptr == value);
     BOOST_TEST(ptr == &value);
@@ -70,7 +70,7 @@ void test_takeAddress_documentation()
 
   // the test
   BOOST_TEST(ptrs.size() == data.size());
-  for (auto&& [value, ptr] : ranges::views::zip(data, ptrs)) {
+  for (auto&& [value, ptr] : util::zip(data, ptrs)) {
     BOOST_TEST(ptr);
     BOOST_TEST(*ptr == value);
     BOOST_TEST(ptr == &value);
@@ -86,7 +86,7 @@ void test_takeAddress()
   std::vector<int const*> dataPtr;
   std::transform(data.cbegin(), data.cend(), std::back_inserter(dataPtr), util::takeAddress());
 
-  for (auto&& [value, ptr] : ranges::views::zip(data, dataPtr)) {
+  for (auto&& [value, ptr] : util::zip(data, dataPtr)) {
     BOOST_TEST(ptr);
     BOOST_TEST(*ptr == value);
     BOOST_TEST(ptr == &value);
@@ -108,7 +108,7 @@ void test_takeAddress_whyBother()
   std::transform(
     data.cbegin(), data.cend(), std::back_inserter(dataPtr), ((addressof_t)&std::addressof));
 
-  for (auto&& [value, ptr] : ranges::views::zip(data, dataPtr)) {
+  for (auto&& [value, ptr] : util::zip(data, dataPtr)) {
     BOOST_TEST(ptr);
     BOOST_TEST(*ptr == value);
     BOOST_TEST(ptr == &value);
@@ -122,7 +122,7 @@ void test_takeAddress_whyBother()
 
   std::transform(data.cbegin(), data.cend(), std::back_inserter(dataPtr), takeAddress);
 
-  for (auto&& [value, ptr] : ranges::views::zip(data, dataPtr)) {
+  for (auto&& [value, ptr] : util::zip(data, dataPtr)) {
     BOOST_TEST(ptr);
     BOOST_TEST(*ptr == value);
     BOOST_TEST(ptr == &value);
@@ -151,7 +151,7 @@ void test_Dereferencer_documentation()
 
   // the test
   BOOST_TEST(values.size() == data.size());
-  for (auto&& [value, orig] : ranges::views::zip(data, values)) {
+  for (auto&& [value, orig] : util::zip(data, values)) {
     BOOST_TEST(value == orig);
   }
 }
@@ -178,7 +178,7 @@ void test_dereference_documentation()
 
   // the test
   BOOST_TEST(values.size() == data.size());
-  for (auto&& [value, orig] : ranges::views::zip(data, values)) {
+  for (auto&& [value, orig] : util::zip(data, values)) {
     BOOST_TEST(value == orig);
   }
 }
@@ -197,7 +197,7 @@ void test_dereference_C_ptr()
     dataPtrs.cbegin(), dataPtrs.cend(), std::back_inserter(dataAgain), util::dereference());
 
   BOOST_TEST(dataAgain.size() == data.size());
-  for (auto&& [value, valueAgain] : ranges::views::zip(data, dataAgain)) {
+  for (auto&& [value, valueAgain] : util::zip(data, dataAgain)) {
     BOOST_TEST(valueAgain == value);
     BOOST_TEST(&valueAgain != &value);
   }
@@ -219,7 +219,7 @@ void test_dereference_unique_ptr()
     dataPtrs.cbegin(), dataPtrs.cend(), std::back_inserter(dataAgain), util::dereference());
 
   BOOST_TEST(dataAgain.size() == data.size());
-  for (auto&& [value, valueAgain] : ranges::views::zip(data, dataAgain)) {
+  for (auto&& [value, valueAgain] : util::zip(data, dataAgain)) {
     BOOST_TEST(valueAgain == value);
     BOOST_TEST(&valueAgain != &value);
   }

--- a/test/CoreUtils/span_test.cc
+++ b/test/CoreUtils/span_test.cc
@@ -13,12 +13,10 @@
 
 // LArSoft libraries
 #include "larcorealg/CoreUtils/counter.h"
+#include "larcorealg/CoreUtils/enumerate.h"
 #include "larcorealg/CoreUtils/operations.h"
 #include "larcorealg/CoreUtils/span.h"
 #include "larcorealg/CoreUtils/zip.h"
-
-#include "range/v3/view/enumerate.hpp"
-#include "range/v3/view/zip.hpp"
 
 // C/C++ standard libraries
 #include <iostream>    // std::cout
@@ -106,7 +104,7 @@ void test_adapted_span(Cont& v)
   BOOST_TEST(r.size() == v.size());
 
   unsigned int n = 0;
-  for (auto&& [rangeValue, value] : ranges::views::zip(r, v)) {
+  for (auto&& [rangeValue, value] : util::zip(r, v)) {
     BOOST_TEST(&rangeValue == &value);
     BOOST_TEST(rangeValue == value);
     ++n;
@@ -176,7 +174,7 @@ void test_transformed_span_with_unmoveable_values(Cont& v)
   BOOST_TEST(r.size() == v.size());
 
   unsigned int n = 0;
-  for (auto&& [rangeValue, value] : ranges::views::zip(r, v)) {
+  for (auto&& [rangeValue, value] : util::zip(r, v)) {
     BOOST_TEST(&rangeValue == &value);
     BOOST_TEST(rangeValue == value);
     ++n;
@@ -291,7 +289,7 @@ struct makeTransformedSpanDocumentation1TestClass {
 
     scale(data, factor);
 
-    for (auto&& [i, ptr] : data | ranges::views::enumerate)
+    for (auto&& [i, ptr] : util::enumerate(data))
       BOOST_TEST(*ptr == factor * i);
   }
 

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -249,7 +249,6 @@ gdmldir	product_dir
 ####################################
 product		version		qual	flags		<table_format=2>
 larcoreobj	v10_00_01	-
-range           v3_0_12_0
 cetmodules	v3_27_04	-	only_for_build
 end_product_list
 ####################################
@@ -305,11 +304,11 @@ end_product_list
 #   case it is optional.
 #
 ####################################
-qualifier	larcoreobj   range      notes
-c14:debug	c14:debug    -nq-
-c14:prof	c14:prof     -nq-
-e26:debug	e26:debug    -nq-
-e26:prof	e26:prof     -nq-
+qualifier	larcoreobj   notes
+c14:debug	c14:debug
+c14:prof	c14:prof
+e26:debug	e26:debug
+e26:prof	e26:prof
 end_qualifier_list
 ####################################
 


### PR DESCRIPTION
This removes rangev3 in the case that larsoft moves to c++20 (which mainlined rangev3 functionality). I hacked in some things to CMakeLists.txt to make this compile with root built with c++17 