### PR TITLE
Silence Clang 14 warning about unused variables

### DIFF
--- a/larcorealg/Geometry/AuxDetSensitiveGeo.h
+++ b/larcorealg/Geometry/AuxDetSensitiveGeo.h
@@ -164,7 +164,7 @@ namespace geo {
 //---
 template <typename Stream>
 void geo::AuxDetSensitiveGeo::PrintAuxDetInfo(Stream&& out,
-                                              std::string indent /* = "" */,
+                                              std::string indent [[maybe_unused]] /* = "" */,
                                               unsigned int verbosity /* = 0 */
 ) const
 {

--- a/larcorealg/Geometry/OpDetGeo.h
+++ b/larcorealg/Geometry/OpDetGeo.h
@@ -258,7 +258,7 @@ bool geo::OpDetGeo::isShapeLike() const
 //------------------------------------------------------------------------------
 template <typename Stream>
 void geo::OpDetGeo::PrintOpDetInfo(Stream&& out,
-                                   std::string indent /* = "" */,
+                                   std::string indent [[maybe_unused]] /* = "" */,
                                    unsigned int verbosity /* = 0 */
 ) const
 {

--- a/larcorealg/Geometry/geo_vectors_utils.h
+++ b/larcorealg/Geometry/geo_vectors_utils.h
@@ -966,7 +966,10 @@ namespace geo {
       Vector* v = nullptr;
       unsigned int index = std::numeric_limits<unsigned int>::max();
 
-      decltype(auto) access(unsigned int c) const { return vect::bindCoord(v, index); }
+      decltype(auto) access(unsigned int c [[maybe_unused]]) const
+      {
+        return vect::bindCoord(v, index);
+      }
 
       iterator_t copy() const { return *this; }
 


### PR DESCRIPTION
This PR silences these Clang 14 warnings:

```
/scratch/knoepfel/sl7-work/larsoft-devel/srcs/larcorealg/larcorealg/Geometry/geo_vectors_utils.h:969:42: error: unused parameter 'c' [-Werror,-Wunused-parameter]                                                                                                       
      decltype(auto) access(unsigned int c) const { return vect::bindCoord(v, index); }                                                                                                                                                                                 
                                         ^                                                                                                                                                                                                                              
In file included from /scratch/knoepfel/sl7-work/larsoft-devel/srcs/larrecodnn/larrecodnn/HDF5Maker/Tables/ChargeHitTable.cxx:4:                                                                                                                                        
In file included from /scratch/knoepfel/sl7-work/larsoft-devel/srcs/larcore/larcore/Geometry/Geometry.h:12:                                                                                                                                                             
In file included from /scratch/knoepfel/sl7-work/larsoft-devel/srcs/larcorealg/larcorealg/Geometry/GeometryCore.h:12:                                                                                                                                                   
In file included from /scratch/knoepfel/sl7-work/larsoft-devel/srcs/larcorealg/larcorealg/Geometry/AuxDetGeo.h:13:                                                                                                                                                      
/scratch/knoepfel/sl7-work/larsoft-devel/srcs/larcorealg/larcorealg/Geometry/AuxDetSensitiveGeo.h:167:59: error: unused parameter 'indent' [-Werror,-Wunused-parameter]                                                                                                 
                                              std::string indent /* = "" */,                                                                                                                                                                                            
                                                          ^                                                                                                                                                                                                             
In file included from /scratch/knoepfel/sl7-work/larsoft-devel/srcs/larrecodnn/larrecodnn/HDF5Maker/Tables/ChargeHitTable.cxx:4:                                                                                                                                        
In file included from /scratch/knoepfel/sl7-work/larsoft-devel/srcs/larcore/larcore/Geometry/Geometry.h:12:                                                                                                                                                             
In file included from /scratch/knoepfel/sl7-work/larsoft-devel/srcs/larcorealg/larcorealg/Geometry/GeometryCore.h:15:                                                                                                                                                   
In file included from /scratch/knoepfel/sl7-work/larsoft-devel/srcs/larcorealg/larcorealg/Geometry/CryostatGeo.h:14:                                                                                                                                                    
/scratch/knoepfel/sl7-work/larsoft-devel/srcs/larcorealg/larcorealg/Geometry/OpDetGeo.h:261:48: error: unused parameter 'indent' [-Werror,-Wunused-parameter]                                                                                                           
                                   std::string indent /* = "" */, 
```